### PR TITLE
Make CHD support optional (WITH_CHD) + a few other changes in blkdev_cdimage/hardfile

### DIFF
--- a/od-win32/sysconfig.h
+++ b/od-win32/sysconfig.h
@@ -75,6 +75,7 @@
 #define SANA2 /* SANA2 network driver */
 #define AMAX /* A-Max ROM adapater emulation */
 #define RETROPLATFORM /* Cloanto RetroPlayer support */
+#define WITH_CHD
 #define WITH_LUA /* lua scripting */
 
 #else


### PR DESCRIPTION
- removed static for a couple of functions which are used elsewhere in FS-UAE)
- a few log macros are changed to fix some compiler warnings
- added long-long (ll) modifier in a log statement logging a 64-bit int.
- removed an unused variable
