### PR TITLE
fix implicit declarations which truncate pointers on 64bit

### DIFF
--- a/include/a2091.h
+++ b/include/a2091.h
@@ -1,4 +1,10 @@
+#ifndef A2091_H
+#define A2091_H
+
 #ifdef A2091
+
+#include "filesys.h"
+#include "memory.h"
 
 extern addrbank dmaca2091_bank;
 
@@ -35,3 +41,6 @@ extern int add_scsi_cd (int ch, int unitnum);
 extern int add_scsi_tape (int ch, const TCHAR *tape_directory, bool readonly);
 
 #endif
+
+#endif
+

--- a/include/blkdev.h
+++ b/include/blkdev.h
@@ -1,3 +1,5 @@
+#ifndef BLKDEV_H
+#define BLKDEV_H
 
 #define DEVICE_SCSI_BUFSIZE (65536 - 1024)
 
@@ -210,3 +212,6 @@ extern void blkdev_entergui (void);
 extern void blkdev_exitgui (void);
 
 bool filesys_do_disk_change (int, bool);
+
+#endif
+

--- a/include/custom.h
+++ b/include/custom.h
@@ -6,7 +6,11 @@
 * (c) 1995 Bernd Schmidt
 */
 
+#ifndef CUSTOM_H
+#define CUSTOM_H
+
 #include "machdep/rpt.h"
+#include "options.h"
 
 /* These are the masks that are ORed together in the chipset_mask option.
 * If CSMASK_AGA is set, the ECS bits are guaranteed to be set as well.  */
@@ -231,3 +235,6 @@ extern bool ispal (void);
 extern int current_maxvpos (void);
 extern struct chipset_refresh *get_chipset_refresh (void);
 extern void compute_framesync (void);
+
+#endif
+

--- a/include/filesys.h
+++ b/include/filesys.h
@@ -6,6 +6,9 @@
   * Copyright 1997 Bernd Schmidt
   */
 
+#ifndef FILESYS_H
+#define FILESYS_H
+
 struct hardfilehandle;
 
 #define MAX_HDF_CACHE_BLOCKS 128
@@ -145,4 +148,6 @@ extern int hdf_resize_target (struct hardfiledata *hfd, uae_u64 newsize);
 extern void getchsgeometry (uae_u64 size, int *pcyl, int *phead, int *psectorspertrack);
 extern void getchsgeometry_hdf (struct hardfiledata *hfd, uae_u64 size, int *pcyl, int *phead, int *psectorspertrack);
 extern void getchspgeometry (uae_u64 total, int *pcyl, int *phead, int *psectorspertrack, bool idegeometry);
+
+#endif
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -6,6 +6,9 @@
 * Copyright 1995 Bernd Schmidt
 */
 
+#ifndef MEMORY_H
+#define MEMORY_H
+
 extern void memory_reset (void);
 extern void a1000_reset (void);
 
@@ -440,3 +443,6 @@ extern void memcpyah (uae_u8 *dst, uaecptr src, int size);
 
 extern uae_s32 getz2size (struct uae_prefs *p);
 extern ULONG getz2endaddr (void);
+
+#endif
+

--- a/include/options.h
+++ b/include/options.h
@@ -7,6 +7,9 @@
 * Copyright 1995-2001 Bernd Schmidt
 */
 
+#ifndef OPTIONS_H
+#define OPTIONS_H
+
 #define UAEMAJOR 2
 #define UAEMINOR 7
 #define UAESUBREV 1
@@ -664,3 +667,6 @@ extern struct uae_prefs currprefs, changed_prefs;
 
 extern int machdep_init (void);
 extern void machdep_free (void);
+
+#endif
+

--- a/include/scsi.h
+++ b/include/scsi.h
@@ -1,3 +1,8 @@
+#ifndef SCSI_H
+#define SCSI_H
+
+#include "filesys.h"
+#include "blkdev.h"
 
 #define SCSI_DATA_BUFFER_SIZE (512 * 512)
 
@@ -109,3 +114,6 @@ extern void tape_media_change (int unitnum, struct uaedev_config_info*);
 #define SCSI_STATUS_COMMAND_TERMINATED     0x22
 #define SCSI_STATUS_QUEUE_FULL             0x28
 #define SCSI_STATUS_ACA_ACTIVE             0x30
+
+#endif
+

--- a/qemuvga/cirrus_vga.cpp
+++ b/qemuvga/cirrus_vga.cpp
@@ -35,6 +35,7 @@
 #else
 #include "qemuuaeglue.h"
 #endif
+#include <string.h> /* memmove */
 
 /*
  * TODO:

--- a/qemuvga/vga.cpp
+++ b/qemuvga/vga.cpp
@@ -37,6 +37,7 @@
 #include "vga.h"
 #include "vga_int.h"
 #endif
+#include <string.h> /* memcpy */
 //#define DEBUG_VGA
 //#define DEBUG_VGA_MEM
 //#define DEBUG_VGA_REG


### PR DESCRIPTION
and some places where header inclusions were missing (requires
double-inclusion guards in some of the affected headers).
