### PR TITLE
cd32_fmv.cpp: compilation fixes

### DIFF
--- a/cd32_fmv.cpp
+++ b/cd32_fmv.cpp
@@ -22,10 +22,15 @@
 #include "custom.h"
 
 #include "cda_play.h"
-#include "archivers\mp2\kjmp2.h"
+#include "archivers/mp2/kjmp2.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "mpeg2.h"
 #include "mpeg2convert.h"
-
+#ifdef __cplusplus
+}
+#endif
 
 #define FMV_DEBUG 0
 static int fmv_audio_debug = 0;
@@ -1432,7 +1437,7 @@ void cd32_fmv_vsync_handler(void)
 	l64111_regs[A_CB_STATUS] -= PCM_SECTORS;
 }
 
-static addrbank fmv_bank = {
+addrbank fmv_bank = {
 	fmv_lget, fmv_wget, fmv_bget,
 	fmv_lput, fmv_wput, fmv_bput,
 	default_xlate, default_check, NULL, _T("CD32 FMV IO"),
@@ -1441,7 +1446,7 @@ static addrbank fmv_bank = {
 
 MEMORY_FUNCTIONS_NOJIT(fmv_rom);
 
-static addrbank fmv_rom_bank = {
+addrbank fmv_rom_bank = {
 	fmv_rom_lget, fmv_rom_wget, fmv_rom_bget,
 	fmv_rom_lput, fmv_rom_wput, fmv_rom_bput,
 	fmv_rom_xlate, fmv_rom_check, NULL, _T("CD32 FMV ROM"),
@@ -1451,7 +1456,7 @@ static addrbank fmv_rom_bank = {
 
 MEMORY_FUNCTIONS_NOJIT(fmv_ram);
 
-static addrbank fmv_ram_bank = {
+addrbank fmv_ram_bank = {
 	fmv_ram_lget, fmv_ram_wget, fmv_ram_bget,
 	fmv_ram_lput, fmv_ram_wput, fmv_ram_bput,
 	fmv_ram_xlate, fmv_ram_check, NULL, _T("CD32 FMV RAM"),


### PR DESCRIPTION
- Use forward slashes
- libmpeg2 headers do not have extern "C" guards, so adding around includes instead
- remove a few static modifiers because they have already been (forward) declared extern
