### PR TITLE
slirp-related compilation changes

### DIFF
--- a/ethernet.cpp
+++ b/ethernet.cpp
@@ -79,9 +79,11 @@ void ethernet_trigger (void *vsd)
 			}
 		}
 		return;
+#ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
 		uaenet_trigger (vsd);
 		return;
+#endif
 	}
 }
 
@@ -107,7 +109,11 @@ int ethernet_open (struct netdriverdata *ndd, void *vsd, void *user, ethernet_go
 					    inet_aton("10.0.2.15", &a);
 						slirp_redir (0, sr->dstport, a, sr->dstport);
 					} else {
+#ifdef HAVE_STRUCT_IN_ADDR_S_UN
 						a.S_un.S_addr = sr->addr;
+#else
+						a.s_addr = sr->addr;
+#endif
 						slirp_redir (sr->proto == 1 ? 0 : 1, sr->dstport, a, sr->srcport);
 					}
 				}
@@ -130,8 +136,10 @@ int ethernet_open (struct netdriverdata *ndd, void *vsd, void *user, ethernet_go
 			slirp_start ();
 		}
 		return 1;
+#ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
 		return uaenet_open (vsd, ndd, user, gotfunc, getfunc, promiscuous);
+#endif
 	}
 	return 0;
 }
@@ -152,14 +160,18 @@ void ethernet_close (struct netdriverdata *ndd, void *vsd)
 			uae_sem_destroy (&slirp_sem2);
 		}
 		return;
+#ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
 		return uaenet_close (vsd);
+#endif
 	}
 }
 
 void ethernet_enumerate_free (void)
 {
+#ifdef WITH_UAENET_PCAP
 	uaenet_enumerate_free ();
+#endif
 }
 
 bool ethernet_enumerate (struct netdriverdata **nddp, const TCHAR *name)
@@ -173,8 +185,10 @@ bool ethernet_enumerate (struct netdriverdata **nddp, const TCHAR *name)
 			*nddp = &slirpd;
 		if (!_tcsicmp (slirpd2.name, name))
 			*nddp = &slirpd2;
+#ifdef WITH_UAENET_PCAP
 		if (*nddp == NULL)
 			*nddp = uaenet_enumerate (name);
+#endif
 		if (*nddp) {
 			netmode = (*nddp)->type;
 			return true;
@@ -184,12 +198,14 @@ bool ethernet_enumerate (struct netdriverdata **nddp, const TCHAR *name)
 	j = 0;
 	nddp[j++] = &slirpd;
 	nddp[j++] = &slirpd2;
+#ifdef WITH_UAENET_PCAP
 	nd = uaenet_enumerate (NULL);
 	if (nd) {
 		for (int i = 0; i < nd[i].active; i++) {
 			nddp[j++] = nd;
 		}
 	}
+#endif
 	nddp[j] = NULL;
 	return true;
 }
@@ -201,8 +217,10 @@ void ethernet_close_driver (struct netdriverdata *ndd)
 		case UAENET_SLIRP:
 		case UAENET_SLIRP_INBOUND:
 		return;
+#ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
 		return uaenet_close_driver (ndd);
+#endif
 	}
 	netmode = 0;
 }
@@ -214,8 +232,10 @@ int ethernet_getdatalenght (struct netdriverdata *ndd)
 		case UAENET_SLIRP:
 		case UAENET_SLIRP_INBOUND:
 		return sizeof (struct ethernet_data);
+#ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
 		return uaenet_getdatalenght ();
+#endif
 	}
 	return 0;
 }

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -1,4 +1,5 @@
-
+#ifndef _UAE_ETHERNET_H_
+#define _UAE_ETHERNET_H_
 
 #define UAENET_NONE 0
 #define UAENET_SLIRP 1
@@ -8,11 +9,11 @@
 struct netdriverdata
 {
 	int type;
-    TCHAR *name;
-    TCHAR *desc;
-    int mtu;
-    uae_u8 mac[6];
-    int active;
+	const TCHAR *name;
+	const TCHAR *desc;
+	int mtu;
+	uae_u8 mac[6];
+	int active;
 };
 
 
@@ -33,3 +34,5 @@ extern void ethernet_trigger (void*);
 
 extern bool slirp_start (void);
 extern void slirp_end (void);
+
+#endif // _UAE_ETHERNET_H_

--- a/include/sana2.h
+++ b/include/sana2.h
@@ -6,6 +6,8 @@
   * (c) 2007 Toni Wilen
   */
 
+#define MAX_TOTAL_NET_DEVICES 10
+
 uaecptr netdev_startup (uaecptr resaddr);
 void netdev_install (void);
 void netdev_reset (void);

--- a/od-win32/sysconfig.h
+++ b/od-win32/sysconfig.h
@@ -86,6 +86,7 @@
 #define WITH_UAENATIVE
 #define WITH_SLIRP
 #define WITH_TABLETLIBRARY
+#define WITH_UAENET_PCAP
 
 #else
 
@@ -553,3 +554,6 @@
 
 #define FSDB_DIR_SEPARATOR '\\'
 #define FSDB_DIR_SEPARATOR_S _T("\\")
+
+/* Define to 1 if `S_un' is a member of `struct in_addr'. */
+#define HAVE_STRUCT_IN_ADDR_S_UN 1

--- a/od-win32/win32_uaenet.h
+++ b/od-win32/win32_uaenet.h
@@ -4,8 +4,6 @@
 typedef void (uaenet_gotfunc)(struct s2devstruct *dev, const uae_u8 *data, int len);
 typedef int (uaenet_getfunc)(struct s2devstruct *dev, uae_u8 *d, int *len);
 
-#define MAX_TOTAL_NET_DEVICES 10
-
 extern struct netdriverdata *uaenet_enumerate (const TCHAR *name);
 extern void uaenet_enumerate_free (void);
 extern void uaenet_close_driver (struct netdriverdata *tc);
@@ -14,7 +12,5 @@ extern int uaenet_getdatalenght (void);
 extern int uaenet_getbytespending (void*);
 extern int uaenet_open (void*, struct netdriverdata*, void*, uaenet_gotfunc*, uaenet_getfunc*, int);
 extern void uaenet_close (void*);
-extern void uaenet_gotdata (struct s2devstruct *dev, const uae_u8 *data, int len);
-extern int uaenet_getdata (struct s2devstruct *dev, uae_u8 *d, int *len);
 extern void uaenet_trigger (void*);
 

--- a/sana2.cpp
+++ b/sana2.cpp
@@ -25,8 +25,15 @@
 #include "blkdev.h"
 #include "uae.h"
 #include "sana2.h"
+#if defined(_WIN32) && defined(WITH_UAENET_PCAP)
 #include "win32_uaenet.h"
+#else
+#include "ethernet.h"
+#endif
 #include "execio.h"
+
+void uaenet_gotdata (struct s2devstruct *dev, const uae_u8 *data, int len);
+int uaenet_getdata (struct s2devstruct *dev, uae_u8 *d, int *len);
 
 #define SANA2NAME _T("uaenet.device")
 
@@ -149,7 +156,7 @@ static uaecptr ROM_netdev_resname = 0,
 	ROM_netdev_resid = 0,
 	ROM_netdev_init = 0;
 
-static TCHAR *getdevname (void)
+static const TCHAR *getdevname (void)
 {
 	return _T("uaenet.device");
 }
@@ -881,7 +888,7 @@ static struct s2packet *createwritepacket (TrapContext *ctx, uaecptr request)
 	return s2p;
 }
 
-static int uaenet_getdata (struct s2devstruct *dev, uae_u8 *d, int *len)
+int uaenet_getdata (struct s2devstruct *dev, uae_u8 *d, int *len)
 {
 	int gotit;
 	struct asyncreq *ar;

--- a/slirp/bootp.cpp
+++ b/slirp/bootp.cpp
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <slirp.h>
+#include "slirp.h"
 
 /* XXX: only DHCP is supported */
 

--- a/slirp/cksum.cpp
+++ b/slirp/cksum.cpp
@@ -30,7 +30,7 @@
  * in_cksum.c,v 1.2 1994/08/02 07:48:16 davidg Exp
  */
 
-#include <slirp.h>
+#include "slirp.h"
 
 /*
  * Checksum routine for Internet Protocol family headers (Portable Version).

--- a/slirp/if.cpp
+++ b/slirp/if.cpp
@@ -5,7 +5,7 @@
  * terms and conditions of the copyright.
  */
 
-#include <slirp.h>
+#include "slirp.h"
 
 int if_mtu, if_mru;
 int if_comp;

--- a/slirp/ip_input.cpp
+++ b/slirp/ip_input.cpp
@@ -38,7 +38,7 @@
  * terms and conditions of the copyright.
  */
 
-#include <slirp.h>
+#include "slirp.h"
 #include "ip_icmp.h"
 
 int ip_defttl;

--- a/slirp/ip_output.cpp
+++ b/slirp/ip_output.cpp
@@ -38,7 +38,7 @@
  * terms and conditions of the copyright.
  */
 
-#include <slirp.h>
+#include "slirp.h"
 
 u_int16_t ip_id;
 

--- a/slirp/libslirp.h
+++ b/slirp/libslirp.h
@@ -32,7 +32,6 @@ int slirp_redir(int is_udp, int host_port,
 int slirp_add_exec(int do_pty, const char *args, int addr_low_byte, 
                    int guest_port);
 
-extern const char *tftp_prefix;
 extern char slirp_hostname[33];
 
 #ifdef __cplusplus

--- a/slirp/mbuf.cpp
+++ b/slirp/mbuf.cpp
@@ -16,7 +16,7 @@
  */
 
 #include <stdlib.h>
-#include <slirp.h>
+#include "slirp.h"
 
 struct	mbuf *mbutl;
 char	*mclrefcnt;

--- a/slirp/misc.cpp
+++ b/slirp/misc.cpp
@@ -7,7 +7,7 @@
 
 #define WANT_SYS_IOCTL_H
 #include <stdlib.h>
-#include <slirp.h>
+#include "slirp.h"
 
 u_int curtime, time_fasttimo, last_slowtimo, detach_time;
 u_int detach_wait = 600000;	/* 10 minutes */
@@ -212,8 +212,7 @@ fork_exec(struct socket *so, char *ex, int do_pty)
 #else
 
 int
-slirp_openpty(amaster, aslave)
-     int *amaster, *aslave;
+slirp_openpty(int *amaster, int *aslave)
 {
 	register int master, slave;
 
@@ -288,10 +287,7 @@ slirp_openpty(amaster, aslave)
  * do_ptr = 2   Fork/exec using pty
  */
 int
-fork_exec(so, ex, do_pty)
-	struct socket *so;
-	char *ex;
-	int do_pty;
+fork_exec(struct socket *so, char *ex, int do_pty)
 {
 	int s;
 	struct sockaddr_in addr;

--- a/slirp/sbuf.cpp
+++ b/slirp/sbuf.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <stdlib.h>
-#include <slirp.h>
+#include "slirp.h"
 
 /* Done as a macro in socket.h */
 /* int

--- a/slirp/slirp_config.h
+++ b/slirp/slirp_config.h
@@ -108,7 +108,9 @@
 #undef HAVE_DRAND48
 
 /* Define if you have memmove */
+#ifndef HAVE_MEMMOVE
 #define HAVE_MEMMOVE
+#endif
 
 /* Define if you have gethostid */
 #undef HAVE_GETHOSTID

--- a/slirp/slirpdebug.cpp
+++ b/slirp/slirpdebug.cpp
@@ -6,7 +6,7 @@
  * terms and conditions of the copyright.
  */
 
-#include <slirp.h>
+#include "slirp.h"
 
 FILE *dfd = NULL;
 #ifdef DEBUG

--- a/slirp/socket.cpp
+++ b/slirp/socket.cpp
@@ -7,7 +7,7 @@
 
 #define WANT_SYS_IOCTL_H
 #include <stdlib.h>
-#include <slirp.h>
+#include "slirp.h"
 #include "ip_icmp.h"
 #include "main.h"
 #ifdef __sun__

--- a/slirp/tcp_input.cpp
+++ b/slirp/tcp_input.cpp
@@ -39,7 +39,7 @@
  */
 
 #include <stdlib.h>
-#include <slirp.h>
+#include "slirp.h"
 #include "ip_icmp.h"
 
 struct socket tcb;

--- a/slirp/tcp_output.cpp
+++ b/slirp/tcp_output.cpp
@@ -38,7 +38,7 @@
  * terms and conditions of the copyright.
  */
 
-#include <slirp.h>
+#include "slirp.h"
 
 /*
  * Since this is only used in "stats socket", we give meaning

--- a/slirp/tcp_subr.cpp
+++ b/slirp/tcp_subr.cpp
@@ -40,7 +40,7 @@
 
 #define WANT_SYS_IOCTL_H
 #include <stdlib.h>
-#include <slirp.h>
+#include "slirp.h"
 
 /* patchable/settable parameters for tcp */
 int 	tcp_mssdflt = TCP_MSS;

--- a/slirp/tcp_timer.cpp
+++ b/slirp/tcp_timer.cpp
@@ -30,7 +30,7 @@
  * tcp_timer.c,v 1.2 1994/08/02 07:49:10 davidg Exp
  */
 
-#include <slirp.h>
+#include "slirp.h"
 
 int	tcp_keepidle = TCPTV_KEEP_IDLE;
 int	tcp_keepintvl = TCPTV_KEEPINTVL;

--- a/slirp/tftp.cpp
+++ b/slirp/tftp.cpp
@@ -22,8 +22,10 @@
  * THE SOFTWARE.
  */
 
-#include <slirp.h>
+#include "slirp.h"
+#ifdef _WIN32
 #include <io.h>
+#endif
 
 struct tftp_session {
     int in_use;

--- a/slirp/udp.cpp
+++ b/slirp/udp.cpp
@@ -39,7 +39,7 @@
  */
 
 #include <stdlib.h>
-#include <slirp.h>
+#include "slirp.h"
 #include "ip_icmp.h"
 
 struct udpstat udpstat;


### PR DESCRIPTION
A set of changes to allow slirp functionality to be compiled into FS-UAE.

I've added a couple of defines WITH_UAENET_PCAP and HAVE_STRUCT_IN_ADDR_S_UN, which I have already also added to od-win32/sysconfig.h.

I also moved MAX_TOTAL_NET_DEVICES from win32_uaenet.h to another header file (to make it available to FS-UAE), and similarly moved uaenet_gotdata/uaenet_getdata prototypes to sana2.cpp.
