### PR TITLE
blkdev: make SCSI IOCTL and/or SCSI SPTI optional and other changes

### DIFF
--- a/include/blkdev.h
+++ b/include/blkdev.h
@@ -82,7 +82,7 @@ struct device_info {
 	TCHAR vendorid[10];
 	TCHAR productid[18];
 	TCHAR revision[6];
-	TCHAR *backend;
+	const TCHAR *backend;
 	struct cd_toc_head toc;
 };
 
@@ -202,6 +202,8 @@ extern void blkdev_default_prefs (struct uae_prefs *p);
 extern void blkdev_fix_prefs (struct uae_prefs *p);
 extern int isaudiotrack (struct cd_toc_head*, int block);
 extern int isdatatrack (struct cd_toc_head*, int block);
+void sub_to_interleaved (const uae_u8 *s, uae_u8 *d);
+void sub_to_deinterleaved (const uae_u8 *s, uae_u8 *d);
 
 enum cd_standard_unit { CD_STANDARD_UNIT_DEFAULT, CD_STANDARD_UNIT_AUDIO, CD_STANDARD_UNIT_CDTV, CD_STANDARD_UNIT_CD32 };
 
@@ -213,5 +215,9 @@ extern void blkdev_entergui (void);
 extern void blkdev_exitgui (void);
 
 bool filesys_do_disk_change (int, bool);
+
+extern struct device_functions devicefunc_scsi_ioctl;
+extern struct device_functions devicefunc_scsi_spti;
+extern struct device_functions devicefunc_cdimage;
 
 #endif /* BLKDEV_H */

--- a/od-win32/blkdev_win32_ioctl.cpp
+++ b/od-win32/blkdev_win32_ioctl.cpp
@@ -1530,7 +1530,7 @@ static int ioctl_scsiemu (int unitnum, uae_u8 *cmd)
 	return -1;
 }
 
-struct device_functions devicefunc_win32_ioctl = {
+struct device_functions devicefunc_scsi_ioctl = {
 	_T("IOCTL"),
 	open_bus, close_bus, open_device, close_device, info_device,
 	0, 0, 0,

--- a/od-win32/blkdev_win32_spti.cpp
+++ b/od-win32/blkdev_win32_spti.cpp
@@ -877,7 +877,7 @@ static int rescan (void)
 #endif
 
 
-struct device_functions devicefunc_win32_spti = {
+struct device_functions devicefunc_scsi_spti = {
 	_T("SPTI"),
 	open_scsi_bus, close_scsi_bus, open_scsi_device, close_scsi_device, info_device,
 	execscsicmd_out, execscsicmd_in, execscsicmd_direct,

--- a/od-win32/sysconfig.h
+++ b/od-win32/sysconfig.h
@@ -106,6 +106,9 @@
 
 #endif
 
+#define WITH_SCSI_IOCTL
+#define WITH_SCSI_SPTI
+
 #define A_ZIP
 #define A_RAR
 #define A_7Z


### PR DESCRIPTION
The main purpose of this patch is to allow integrating the Linux SCSI IOCTL code into blkdev. devicefunc_win32_ioctl is renamed to devicefunc_scsi_ioctl, prototypes are moved to blkdev.h. Iterating over the blkdevice functions has been changed to account for either of them missing.

I have already added  the following defines to od-win32/sysconfig.h:
# define WITH_SCSI_IOCTL
# define WITH_SCSI_SPTI

and also renamed devicefunc_win32_\* in od-win32, so hopefully the patch should apply and compile cleanly on WinUAE.

(There's a couple of logging fixes and a const fix too).
