### PR TITLE
expansion.cpp: increase MAX_EXPANSION_BOARDS to 11?

### DIFF
--- a/expansion.cpp
+++ b/expansion.cpp
@@ -33,7 +33,7 @@
 #include "gayle.h"
 #include "cpuboard.h"
 
-#define MAX_EXPANSION_BOARDS 8
+#define MAX_EXPANSION_BOARDS 11
 
 /* ********************************************************** */
 /* 00 / 02 */


### PR DESCRIPTION
Static analysis indicates that the number of expansion boards could reach 10, causing memory corruption. It might not be a real-world problem (cfgfile makes sure some combinations are never used at the same time, etc). To have room for expamem_init_last, MAX_EXPANSION_BOARDS would, to account for the worst case, have to be 11.

You can consider if it is best to increase it to 11 to be on the safe side, or dismiss the pull request if not :)
