### PR TITLE
Small cleanups to fix compiler warnings of GCC

### DIFF
--- a/build68k.cpp
+++ b/build68k.cpp
@@ -78,7 +78,6 @@ int main(int argc, char **argv)
 		int cpulevel, uncpulevel, plevel, sduse;
 		int i;
 
-		char patbits[16];
 		char opcstr[256];
 		int bitpos[16];
 		int flagset[5], flaguse[5];
@@ -127,7 +126,6 @@ int main(int argc, char **argv)
 			bitmask |= 1;
 			if (nextch == '1')
 			bitpattern |= 1;
-			patbits[i] = nextch;
 			getnextch();
 		}
 

--- a/fpp.cpp
+++ b/fpp.cpp
@@ -1104,7 +1104,7 @@ STATIC_INLINE void set_fpsr (uae_u32 x)
 		fpset (&regs.fp_result, 1);
 }
 
-uae_u32 get_ftag (uae_u32 w1, uae_u32 w2, uae_u32 w3, int size)
+static uae_u32 get_ftag (uae_u32 w1, uae_u32 w2, uae_u32 w3, int size)
 {
 	int exp = (w1 >> 16) & 0x7fff;
 	
@@ -1184,7 +1184,7 @@ static void to_pack (fpdata *fpd, uae_u32 *wrd)
 		fpd->fp = d;
 }
 
-void from_pack (fpdata *src, uae_u32 *wrd, int kfactor)
+static void from_pack (fpdata *src, uae_u32 *wrd, int kfactor)
 {
 	int i, j, t;
 	int exp;
@@ -1365,7 +1365,7 @@ static bool fault_if_no_denormal_support_post(uae_u16 opcode, uae_u16 extra, uae
 static int get_fp_value (uae_u32 opcode, uae_u16 extra, fpdata *src, uaecptr oldpc, uae_u32 *adp)
 {
 	int size, mode, reg;
-	uae_u32 ad = 0, ad2;
+	uae_u32 ad = 0;
 	static const int sz1[8] = { 4, 4, 12, 12, 2, 8, 1, 0 };
 	static const int sz2[8] = { 4, 4, 12, 12, 2, 8, 2, 0 };
 	uae_u32 exts[3];
@@ -1485,7 +1485,6 @@ static int get_fp_value (uae_u32 opcode, uae_u16 extra, fpdata *src, uaecptr old
 	}
 
 	*adp = ad;
-	ad2 = ad;
 
 	if (currprefs.fpu_model == 68060 && fault_if_unimplemented_680x0 (opcode, extra, ad, oldpc, src, -1))
 		return -1;
@@ -2218,7 +2217,6 @@ void fpuop_save (uae_u32 opcode)
 
 void fpuop_restore (uae_u32 opcode)
 {
-	int fpu_version = get_fpu_version ();
 	uaecptr pc = m68k_getpc () - 2;
 	uae_u32 ad;
 	uae_u32 d;
@@ -2242,7 +2240,6 @@ void fpuop_restore (uae_u32 opcode)
 		return;
 	regs.fpiar = pc;
 
-	uae_u32 pad = ad;
 	if (incr < 0) {
 		ad -= 4;
 		d = x_get_long (ad);

--- a/gencpu.cpp
+++ b/gencpu.cpp
@@ -95,7 +95,7 @@ static const char *dstblrmw, *dstwlrmw, *dstllrmw;
 static const char *srcbrmw, *srcwrmw, *srclrmw;
 static const char *dstbrmw, *dstwrmw, *dstlrmw;
 static const char *prefetch_long, *prefetch_word;
-static const char *srcli, *srcwi, *srcbi, *nextl, *nextw, *nextb;
+static const char *srcli, *srcwi, *srcbi, *nextl, *nextw;
 static const char *srcld, *dstld;
 static const char *srcwd, *dstwd;
 static const char *do_cycles, *disp000, *disp020, *getpc;
@@ -1935,12 +1935,12 @@ static void genastore_fc (const char *from, amodes mode, const char *reg, wordsi
 static void movem_mmu060 (const char *code, int size, bool put, bool aipi, bool apdi)
 {
 	const char *index;
-	int dphase, aphase;
+	int dphase;
 	if (apdi) {
-		dphase = 1; aphase = 0;
+		dphase = 1;
 		index = "movem_index2";
 	} else {
-		dphase = 0; aphase = 1;
+		dphase = 0;
 		index = "movem_index1";
 	}
 
@@ -2005,20 +2005,18 @@ static bool mmu040_special_movem (uae_u16 opcode)
 static void movem_mmu040 (const char *code, int size, bool put, bool aipi, bool apdi, uae_u16 opcode)
 {
 	const char *index;
-	int dphase, aphase;
-	bool mvm = false;
+	int dphase;
 
 	if (apdi) {
-		dphase = 1; aphase = 0;
+		dphase = 1;
 		index = "movem_index2";
 	} else {
-		dphase = 0; aphase = 1;
+		dphase = 0;
 		index = "movem_index1";
 	}
 
 	printf ("\tmmu040_movem = 1;\n");
 	printf ("\tmmu040_movem_ea = srca;\n");
-	mvm = true;
 
 	for (int i = 0; i < 2; i++) {
 		char reg;
@@ -2050,12 +2048,12 @@ static void movem_mmu040 (const char *code, int size, bool put, bool aipi, bool 
 static void movem_mmu030 (const char *code, int size, bool put, bool aipi, bool apdi)
 {
 	const char *index;
-	int dphase, aphase;
+	int dphase;
 	if (apdi) {
-		dphase = 1; aphase = 0;
+		dphase = 1;
 		index = "movem_index2";
 	} else {
-		dphase = 0; aphase = 1;
+		dphase = 0;
 		index = "movem_index1";
 	}
 	printf ("\tmmu030_state[1] |= MMU030_STATEFLAG1_MOVEM1;\n");
@@ -4961,7 +4959,6 @@ bccl_not68020:
 	case i_BFINS:
 		{
 			const char *getb, *putb;
-			int flags = 0;
 
 			if (using_mmu == 68060 && (curi->mnemo == i_BFCHG || curi->mnemo == i_BFCLR ||  curi->mnemo == i_BFSET ||  curi->mnemo == i_BFINS)) {
 				getb = "mmu060_get_rmw_bitfield";


### PR DESCRIPTION
Hi! When compiling the WinUAE CPU code with with GCC, it warns about unused variables and functions without prototypes. Here are some small fixes to silence these warnings in fpp.cpp, build68k.cpp and gencpu.cpp.