### PR TITLE
Some more small cleanups to fix compiler warnings of GCC

### DIFF
--- a/cpummu.cpp
+++ b/cpummu.cpp
@@ -63,13 +63,12 @@ uae_u32 mmu040_move16[4];
 static void mmu_dump_ttr(const TCHAR * label, uae_u32 ttr)
 {
 	DUNUSED(label);
+#if MMUDEBUG > 0
 	uae_u32 from_addr, to_addr;
 
 	from_addr = ttr & MMU_TTR_LOGICAL_BASE;
 	to_addr = (ttr & MMU_TTR_LOGICAL_MASK) << 8;
 
-	
-#if MMUDEBUG > 0
 	write_log(_T("%s: [%08lx] %08lx - %08lx enabled=%d supervisor=%d wp=%d cm=%02d\n"),
 			label, ttr,
 			from_addr, to_addr,

--- a/cpummu30.cpp
+++ b/cpummu30.cpp
@@ -712,7 +712,6 @@ int mmu030_do_match_lrmw_ttr(uae_u32 tt, TT_info comp, uaecptr addr, uae_u32 fc)
 
 static void mmu030_do_fake_prefetch(void)
 {
-	uaecptr pc = m68k_getpci();
 	// fetch next opcode before MMU state switches.
 	// There are programs that do following:
 	// - enable MMU
@@ -2271,31 +2270,6 @@ uaecptr mmu030_translate(uaecptr addr, bool super, bool data, bool write)
         mmu030_table_search(addr, fc, false, 0);
         return mmu030_get_addr_atc(addr, mmu030_logical_is_in_atc(addr,fc,write), fc, write);
     }
-}
-
-static uae_u32 get_dcache_byte(uaecptr addr)
-{
-	return read_dcache030(addr, 0);
-}
-static uae_u32 get_dcache_word(uaecptr addr)
-{
-	return read_dcache030(addr, 1);
-}
-static uae_u32 get_dcache_long(uaecptr addr)
-{
-	return read_dcache030(addr, 2);
-}
-static void put_dcache_byte(uaecptr addr, uae_u32 v)
-{
-	write_dcache030(addr, v, 0);
-}
-static void put_dcache_word(uaecptr addr, uae_u32 v)
-{
-	write_dcache030(addr, v, 1);
-}
-static void put_dcache_long(uaecptr addr, uae_u32 v)
-{
-	write_dcache030(addr, v, 2);
 }
 
 /* MMU Reset */

--- a/newcpu.cpp
+++ b/newcpu.cpp
@@ -4127,7 +4127,6 @@ void cpu_halt (int id)
 /* MMU 68060  */
 static void m68k_run_mmu060 (void)
 {
-	uaecptr pc;
 	struct flag_struct f;
 	int halt = 0;
 
@@ -4136,7 +4135,7 @@ static void m68k_run_mmu060 (void)
 			for (;;) {
 				f.cznv = regflags.cznv;
 				f.x = regflags.x;
-				pc = regs.instruction_pc = m68k_getpc ();
+				regs.instruction_pc = m68k_getpc ();
 
 				do_cycles (cpu_cycles);
 
@@ -4187,7 +4186,6 @@ static void m68k_run_mmu060 (void)
 static void m68k_run_mmu040 (void)
 {
 	flag_struct f;
-	uaecptr pc;
 	int halt = 0;
 
 	while (!halt) {
@@ -4196,7 +4194,7 @@ static void m68k_run_mmu040 (void)
 				f.cznv = regflags.cznv;
 				f.x = regflags.x;
 				mmu_restart = true;
-				pc = regs.instruction_pc = m68k_getpc ();
+				regs.instruction_pc = m68k_getpc ();
 
 				do_cycles (cpu_cycles);
 
@@ -4242,7 +4240,6 @@ static void m68k_run_mmu040 (void)
 // Previous MMU 68030
 static void m68k_run_mmu030 (void)
 {
-	uaecptr pc;
 	struct flag_struct f;
 	int halt = 0;
 
@@ -4253,7 +4250,7 @@ static void m68k_run_mmu030 (void)
 			for (;;) {
 				int cnt;
 insretry:
-				pc = regs.instruction_pc = m68k_getpc ();
+				regs.instruction_pc = m68k_getpc ();
 				f.cznv = regflags.cznv;
 				f.x = regflags.x;
 


### PR DESCRIPTION
These two patches fix some of the compiler warnings of GCC in the cpummu and newcpu code (about unused variables and functions)