### PR TITLE
merged uae_dlopen_plugin implementations, unified capsimg support

### DIFF
--- a/dlopen.cpp
+++ b/dlopen.cpp
@@ -1,29 +1,37 @@
 #include "sysconfig.h"
 #include "sysdeps.h"
-
+#include "uae/api.h"
 #include "uae/dlopen.h"
-#ifdef _WIN32
+#include "uae/log.h"
 
+#ifdef _WIN32
+#include "windows.h"
 #else
 #include <dlfcn.h>
+#endif
+#ifdef WINUAE
+#include "od-win32/win32.h"
 #endif
 
 UAE_DLHANDLE uae_dlopen(const TCHAR *path)
 {
 	UAE_DLHANDLE result;
-#ifdef WINUAE
-	result = uae_dlopen_plugin(path);
-#elif _WIN32
+	if (path == NULL || path[0] == _T('\0')) {
+		write_log(_T("DLOPEN: No path given\n"));
+		return NULL;
+	}
+#ifdef _WIN32
 	result = LoadLibrary(path);
 #else
 	result = dlopen(path, RTLD_NOW);
 	const char *error = dlerror();
 	if (error != NULL)  {
-		write_log("uae_dlopen failed: %s\n", error);
+		write_log("DLOPEN: %s\n", error);
 	}
 #endif
-	if (result)
-		uae_dlopen_patch_common(result);
+	if (result == NULL) {
+		write_log("DLOPEN: Failed to open %s\n", path);
+	}
 	return result;
 }
 
@@ -50,7 +58,33 @@ void uae_dlclose(UAE_DLHANDLE handle)
 #endif
 }
 
-#include "uae/log.h"
+UAE_DLHANDLE uae_dlopen_plugin(const TCHAR *name)
+{
+#if defined(FSUAE)
+	const TCHAR *path = NULL;
+	if (plugin_lookup) {
+		path = plugin_lookup(name);
+	}
+	if (path == NULL or path[0] == _T('\0')) {
+		write_log(_T("DLOPEN: Could not find plugin \"%s\"\n"), name);
+		return NULL;
+	}
+	UAE_DLHANDLE handle = uae_dlopen(path);
+#else
+	TCHAR path[MAX_DPATH];
+	_tcscpy(path, name);
+#ifdef _WIN64
+	_tcscat(path, _T("_x64"));
+#endif
+	_tcscat(path, LT_MODULE_EXT);
+	UAE_DLHANDLE handle = uae_dlopen(path);
+#endif
+	if (handle) {
+		write_log(_T("DLOPEN: Loaded plugin %s\n"), path);
+		uae_dlopen_patch_common(handle);
+	}
+	return handle;
+}
 
 void uae_dlopen_patch_common(UAE_DLHANDLE handle)
 {

--- a/od-win32/sysconfig.h
+++ b/od-win32/sysconfig.h
@@ -329,6 +329,10 @@
 #undef HAVE_ISINF
 #define isnan _isnan
 
+#ifndef LT_MODULE_EXT
+#define LT_MODULE_EXT _T(".dll")
+#endif
+
 /* Define if you have the bcopy function.  */
 /* #undef HAVE_BCOPY */
 

--- a/od-win32/win32.cpp
+++ b/od-win32/win32.cpp
@@ -6495,27 +6495,6 @@ HMODULE WIN32_LoadLibrary2 (const TCHAR *name)
 	return m;
 }
 
-HMODULE uae_dlopen_plugin(const TCHAR *name)
-{
-	HMODULE h;
-	TCHAR path[MAX_DPATH];
-#ifdef WIN64
-	_tcscpy(path, name);
-	_tcscat(path, _T("_x64.dll"));
-	h = WIN32_LoadLibrary(path);
-	if (h)
-		return h;
-	_tcscpy(path, _T("qemu\\"));
-	_tcscat(path, name);
-	_tcscat(path, _T("_x64.dll"));
-#else
-	_tcscpy(path, name);
-	_tcscat(path, _T(".dll"));
-#endif
-	h = WIN32_LoadLibrary(path);
-	return h;
-}
-
 int isdllversion (const TCHAR *name, int version, int revision, int subver, int subrev)
 {
 	DWORD  dwVersionHandle, dwFileVersionInfoSize;

--- a/qemuvga/qemu.cpp
+++ b/qemuvga/qemu.cpp
@@ -30,7 +30,7 @@ static void init_ppc(UAE_DLHANDLE handle)
 	}
 }
 
-#ifndef WINUAE
+#ifdef WITH_QEMU_SLIRP
 static void init_slirp(UAE_DLHANDLE handle)
 {
 	UAE_IMPORT_FUNCTION(handle, qemu_uae_slirp_init);
@@ -52,7 +52,7 @@ UAE_DLHANDLE uae_qemu_uae_init(void)
 	}
 	initialized = true;
 
-	handle = uae_dlopen(_T("qemu-uae"));
+	handle = uae_dlopen_plugin(_T("qemu-uae"));
 	if (!handle) {
 		gui_message(_T("Error loading qemu-uae plugin\n"));
 		return handle;
@@ -98,8 +98,7 @@ UAE_DLHANDLE uae_qemu_uae_init(void)
 	}
 
 	init_ppc(handle);
-
-#ifndef WINUAE
+#ifdef WITH_QEMU_SLIRP
 	init_slirp(handle);
 #endif
 

--- a/uaenative.cpp
+++ b/uaenative.cpp
@@ -69,9 +69,6 @@ static int g_allocated_handles = 0;
 static int g_max_handle = -1;
 
 #ifdef _WIN32
-#ifndef LT_MODULE_EXT
-#define LT_MODULE_EXT _T(".dll")
-#endif
 #ifndef OS_NAME
 #define OS_NAME _T("windows")
 #endif


### PR DESCRIPTION
This patch unified WinUAE and FS-UAE plugin loading, including FS-UAE using the capsimg loading code from WinUAE. I have tested that WinUAE still loads both capsimg.dll and qemu-uae.dll correctly (both in plugins dir and alsongside winuae.exe).