### PR TITLE
Fixed check for Blizzard cpuboard memtype in main.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -310,7 +310,7 @@ void fixup_cpu (struct uae_prefs *p)
 		error_log(_T("Cycle-exact mode requires at least Disabled but emulated sound setting."));
 	}
 
-	if (p->cpuboard_type && cpuboard_jitdirectompatible(p) && !p->comptrustbyte) {
+	if (p->cachesize && p->cpuboard_type && !cpuboard_jitdirectompatible(p) && !p->comptrustbyte) {
 		error_log(_T("JIT direct is not compatible with emulated Blizzard accelerator boards."));
 		p->comptrustbyte = 1;
 		p->comptrustlong = 1;

--- a/od-win32/mman.cpp
+++ b/od-win32/mman.cpp
@@ -638,7 +638,7 @@ void *uae_shmat (addrbank *ab, int shmid, void *shmaddr, int shmflg)
 			// this is flash and also contains IO
 			shmaddr=natmem_offset + 0xf00000;
 			got = true;
-			readonly = true;
+			readonly = false;
 		} else if (!_tcscmp(shmids[shmid].name, _T("rtarea"))) {
 			shmaddr = natmem_offset + rtarea_base;
 			got = true;


### PR DESCRIPTION
It looks like the cpuboard_jitdirectompatible() check is reversed in main.cpp
(Based on bug report http://eab.abime.net/showpost.php?p=1043088&postcount=911)
- Please double-check that the fix is correct.

I also changed the code so error_log is only used when JIT was actually requested (FS-UAE shows error_log messages in the GUI).