### PR TITLE
Disable some unused functions

### DIFF
--- a/newcpu.cpp
+++ b/newcpu.cpp
@@ -5162,6 +5162,7 @@ static void m68k_run_2 (void)
 }
 
 /* fake MMU 68k  */
+#if 0
 static void m68k_run_mmu (void)
 {
 	for (;;) {
@@ -5178,6 +5179,7 @@ static void m68k_run_mmu (void)
 		}
 	}
 }
+#endif
 
 #endif /* CPUEMU_0 */
 

--- a/newcpu.cpp
+++ b/newcpu.cpp
@@ -5185,6 +5185,7 @@ static void m68k_run_mmu (void)
 
 int in_m68k_go = 0;
 
+#if 0
 static void exception2_handle (uaecptr addr, uaecptr fault)
 {
 	last_addr_for_exception_3 = addr;
@@ -5193,6 +5194,7 @@ static void exception2_handle (uaecptr addr, uaecptr fault)
 	last_instructionaccess_for_exception_3 = 0;
 	Exception (2);
 }
+#endif
 
 static bool cpu_hardreset, cpu_keyboardreset;
 

--- a/newcpu.cpp
+++ b/newcpu.cpp
@@ -4119,7 +4119,7 @@ cont:
 
 #endif
 
-#ifdef CPUEMU_20
+#if defined(CPUEMU_20) && defined(JIT)
 // emulate simple prefetch
 static uae_u16 get_word_020_prefetchf (uae_u32 pc)
 {


### PR DESCRIPTION
When compiling with GCC and default warnings enabled, GCC complains about static functions that are not called anywhere. It would be nice to get rid of these warnings by disabling these unused functions (or maybe m68k_run_mmu() and/or exception2_handle() should be removed completely instead?). Thanks!