### PR TITLE
Some patches to silence some more GCC compiler warnings

### DIFF
--- a/fpp.cpp
+++ b/fpp.cpp
@@ -1022,16 +1022,16 @@ static tointtype toint(fpdata *src, int size)
 			switch (regs.fpcr & 0x30)
 			{
 				case FPCR_ROUND_ZERO:
-					result = (int)fp_round_to_zero (fp);
+					result = fp_round_to_zero (fp);
 					break;
 				case FPCR_ROUND_MINF:
-					result = (int)fp_round_to_minus_infinity (fp);
+					result = fp_round_to_minus_infinity (fp);
 					break;
 				case FPCR_ROUND_NEAR:
 					result = fp_round_to_nearest (fp);
 					break;
 				case FPCR_ROUND_PINF:
-					result = (int)fp_round_to_plus_infinity (fp);
+					result = fp_round_to_plus_infinity (fp);
 					break;
 			}
 			return result;

--- a/gencpu.cpp
+++ b/gencpu.cpp
@@ -247,12 +247,6 @@ static void get_prefetch_020 (void)
 		return;
 	printf ("\tregs.irc = %s (%d);\n", prefetch_word, m68k_pc_offset);
 }
-static void get_prefetch_020_0 (void)
-{
-	if (!isprefetch020() || no_prefetch_ce020)
-		return;
-	printf ("\tregs.irc = %s (0);\n", prefetch_word);
-}
 static void get_prefetch_020_continue(void)
 {
 	if (!isprefetch020())

--- a/newcpu_common.cpp
+++ b/newcpu_common.cpp
@@ -818,7 +818,7 @@ bool m68k_divl (uae_u32 opcode, uae_u32 src, uae_u16 extra)
 			a |= (uae_s64)m68k_dreg (regs, extra & 7) << 32;
 		}
 
-		if (a == 0x8000000000000000 && src == ~0u) {
+		if ((uae_u64)a == 0x8000000000000000UL && src == ~0u) {
 			SET_VFLG (1);
 			SET_NFLG (1);
 			SET_CFLG (0);


### PR DESCRIPTION
Toni, here are some more few patches that help to silence some of the remaining warnings that I get when compiling the files in Hatari with GCC. Would be great to see the changes in WinUAE, too, so that the sources stay in sync. Thanks!