### PR TITLE
Two small fixes

### DIFF
--- a/cpummu30.cpp
+++ b/cpummu30.cpp
@@ -2724,7 +2724,7 @@ void m68k_do_rte_mmu030 (uaecptr a7)
 	// Data buffer
 	uae_u32 mmu030_data_buffer_in_v = get_long_mmu030(a7 + 0x2c);;
 
-	uae_u32 mmu030_opcode_v = (ps & 0x80000000) ? -1 : (oc & 0xffff);
+	uae_u32 mmu030_opcode_v = (ps & 0x80000000) ? -1U : (oc & 0xffff);
 	// Misc state data
 	uae_u32 mmu030_state_0 = get_word_mmu030(a7 + 0x30);
 	uae_u32 mmu030_state_1 = get_word_mmu030(a7 + 0x32);
@@ -2771,7 +2771,7 @@ void m68k_do_rte_mmu030 (uaecptr a7)
 		// did we have ins fault and RB bit cleared?
 		if ((ssw & MMU030_SSW_FB) && !(ssw & MMU030_SSW_RB)) {
 			uae_u16 stageb = get_word_mmu030 (a7 + 0x0e);
-			if (mmu030_opcode_v == -1) {
+			if (mmu030_opcode_v == -1U) {
 				mmu030_opcode_stageb = stageb;
 				write_log (_T("Software fixed stage B! opcode = %04x\n"), stageb);
 			} else {
@@ -3112,7 +3112,7 @@ void m68k_do_rte_mmu030c (uaecptr a7)
 	// Data buffer
 	uae_u32 mmu030_data_buffer_in_v = get_long_mmu030c(a7 + 0x2c);;
 
-	uae_u32 mmu030_opcode_v = (ps & 0x80000000) ? -1 : (oc & 0xffff);
+	uae_u32 mmu030_opcode_v = (ps & 0x80000000) ? -1U : (oc & 0xffff);
 	// Misc state data
 	uae_u32 mmu030_state_0 = get_word_mmu030c(a7 + 0x30);
 	uae_u32 mmu030_state_1 = get_word_mmu030c(a7 + 0x32);
@@ -3164,7 +3164,7 @@ void m68k_do_rte_mmu030c (uaecptr a7)
 		regs.pipeline_r8[0] = (ps >> 8) & 7;
 		regs.pipeline_r8[1] = (ps >> 11) & 7;
 		regs.pipeline_pos = (ps >> 16) & 15;
-		regs.pipeline_stop = ((ps >> 20) & 15) == 15 ? -1 : (ps >> 20) & 15;
+		regs.pipeline_stop = ((ps >> 20) & 15) == 15 ? -1 : (int)(ps >> 20) & 15;
 
 		regs.prefetch020[2] = stagesbc;
 		regs.prefetch020[1] = stagesbc >> 16;

--- a/fpp.cpp
+++ b/fpp.cpp
@@ -989,7 +989,7 @@ static void fp_unimp_datatype(uae_u16 opcode, uae_u16 extra, uae_u32 ea, uaecptr
 				fsave_data.stag = 7; // undocumented
 			} else {
 				fpp_from_exten_fmovem(src, &fsave_data.et[0], &fsave_data.et[1], &fsave_data.et[2]);
-				fsave_data.stag = get_ftag(src, (opclass == 0) ? -1 : size);
+				fsave_data.stag = get_ftag(src, (opclass == 0) ? -1U : size);
 				if (fsave_data.stag == 5) {
 					fsave_data.et[0] = (size == 1) ? 0x3f800000 : 0x3c000000; // exponent for denormalized single and double
 				}

--- a/scsi.cpp
+++ b/scsi.cpp
@@ -1241,10 +1241,8 @@ static int getmsglen(uae_u8 *msgp, int len)
 	uae_u8 msg = msgp[0];
 	if (msg == 0 || (msg >= 0x02 && msg <= 0x1f) ||msg >= 0x80)
 		return 1;
-	if (msg >= 0x02 && msg <= 0x1f)
-		return 2;
 	if (msg >= 0x20 && msg <= 0x2f)
-		return 3;
+		return 2;
 	// extended message, at least 3 bytes
 	if (len < 2)
 		return 3;


### PR DESCRIPTION
First patch silences some compiler warnings when compiling with -Wsign-compare, and the second patch fixes the wrong if-statement in the getmsglen() function in scsi.cpp.