### PR TITLE
Fixed read order

### DIFF
--- a/cputest/main.c
+++ b/cputest/main.c
@@ -1107,8 +1107,10 @@ static uae_u8 *validate_exception(struct registers *regs, uae_u8 *p, int excnum,
 			exc[0] = regs->sr >> 8;
 			exc[1] = regs->sr;
 			pl(exc + 2, regs->pc);
+			const uae_u16 t0 = *p++;
+			const uae_u16 t1 = *p++;
 			// frame type
-			uae_u16 frame = ((*p++) << 8) | (*p++);
+			uae_u16 frame = (t0 << 8) | t1;
 			exc[6] = frame >> 8;
 			exc[7] = frame >> 0;
 


### PR DESCRIPTION
When compiling with clang it will complain about

```
multiple unsequenced modifications to 'p' [-Wunsequenced]
```
This is because doing changes such as `variable++` twice or more on the same line the order of which one that happens first is undefined. This PR does the reads to two separate variables first to guarantee the ordering is correct.