### PR TITLE
Silence some compiler warnings in the CPU code

### DIFF
--- a/gencpu.cpp
+++ b/gencpu.cpp
@@ -9450,7 +9450,7 @@ static void generate_one_opcode (int rp, const char *extra)
 	printf("%s", outbuffer);
 
 	// generate noflags variant if needed
-	int nfgenerated = 0;
+	NOWARN_UNUSED(int nfgenerated = 0);
 	if (using_noflags && table68k[opcode].flagdead != 0 && !disable_noflags) {
 		convert_to_noflags(outbuffer);
 		printf("%s", outbuffer);

--- a/include/readcpu.h
+++ b/include/readcpu.h
@@ -126,6 +126,7 @@ extern struct instr {
 	char head, tail, clocks, fetchmode;
 } *table68k;
 
+extern void do_merges(void);
 extern void init_table68k(void);
 extern void exit_table68k(void);
 

--- a/newcpu.cpp
+++ b/newcpu.cpp
@@ -1807,6 +1807,8 @@ static const struct cputbl *cputbls[6][8] =
 	{ op_smalltbl_0, op_smalltbl_40, op_smalltbl_50, op_smalltbl_24, op_smalltbl_24, op_smalltbl_33, op_smalltbl_33, op_smalltbl_33 }
 };
 
+#ifdef JIT
+
 const struct cputbl *uaegetjitcputbl(void)
 {
 	int lvl = (currprefs.cpu_model - 68000) / 10;
@@ -1820,6 +1822,8 @@ const struct cputbl *getjitcputbl(int cpulvl, int direct)
 {
 	return cputbls[cpulvl][1 + direct];
 }
+
+#endif
 
 static void build_cpufunctbl (void)
 {


### PR DESCRIPTION
There are currently a bunch of GCC compiler warnings when compiling the CPU code in Hatari. Here are the fixes to silence them.