### PR TITLE
Avoid using isspace() with signed characters

### DIFF
--- a/build68k.cpp
+++ b/build68k.cpp
@@ -311,12 +311,12 @@ int main(int argc, char **argv)
 		char tmp[100], *p;
 		int slen = 0;
 
-		while (isspace(*opstrp))
+		while (isspace((unsigned char)*opstrp))
 			opstrp++;
 
 		osendp = opstrp;
 		while (*osendp) {
-			if (!isspace (*osendp))
+			if (!isspace ((unsigned char)*osendp))
 				slen = osendp - opstrp + 1;
 			osendp++;
 		}
@@ -328,7 +328,7 @@ int main(int argc, char **argv)
 		strcpy (tmp, opstrp);
 		strcat (tmp, " ");
 		p = tmp;
-		while (!isspace(*p++));
+		while (!isspace((unsigned char)*p++));
 		*p = 0;
 		printf("/* %s */\n", tmp);
 		printf("{0x%04X,%2d,{", bitpattern, n_variable);


### PR DESCRIPTION
"char" is signed by default on many systems, so when using a "char"
variable as input to isspace(), which takes an "int" parameter, the
parameter gets sign-extended. Now in some libc implementations, the
isspace() function is implemented as a macro that directly indexes
an array for looking up the result - which might go wrong, of course,
if the byte values has the highest bit set. So when compiling Hatari
with Cygwin, there are the following compiler warnings:

.../build68k.c: In function ‘main’:
.../build68k.c:314:18: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  314 |   while (isspace(*opstrp))
      |                  ^~~~~~~
.../build68k.c:319:18: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  319 |    if (!isspace (*osendp))
      |                  ^~~~~~~
.../build68k.c:331:19: warning: array subscript has type ‘char’ [-Wchar-subscripts]
  331 |   while (!isspace(*p++));
      |                   ^~~~

Thus let's make sure to cast the "char" to unsigned first before using
it as parameter to the isspace() function.