### PR TITLE
Fix typos and compiler warning

### DIFF
--- a/cpummu30.cpp
+++ b/cpummu30.cpp
@@ -2347,7 +2347,8 @@ void mmu030_put_generic(uaecptr addr, uae_u32 val, uae_u32 fc, int size, int fla
  	mmu030_cache_state = CACHE_ENABLE_ALL;
 
 	if (flags & MMU030_SSW_RM) {
-		return mmu030_put_generic_lrmw(addr, val, fc, size, flags);
+		mmu030_put_generic_lrmw(addr, val, fc, size, flags);
+		return;
 	}
 
 	if (fc != 7 && (!tt_enabled || !mmu030_match_ttr_access(addr,fc,true)) && mmu030.enabled) {

--- a/cputest.cpp
+++ b/cputest.cpp
@@ -2897,7 +2897,7 @@ static int create_ea_random(uae_u16 *opcodep, uaecptr pc, int mode, int reg, str
 			put_word_test(pc, v);
 			uaecptr pce = pc;
 			pc += 2;
-			// calculate lenght of extension
+			// calculate length of extension
 			if (mode == Ad8r && reg == 7 && flagsp) {
 				*flagsp |= EAFLAG_SP;
 			}
@@ -3153,7 +3153,7 @@ static int create_ea_random(uae_u16 *opcodep, uaecptr pc, int mode, int reg, str
 				} else if (dp->mnemo == i_BSR || dp->mnemo == i_DBcc || dp->mnemo == i_Bcc ||
 					dp->mnemo == i_ORSR || dp->mnemo == i_ANDSR || dp->mnemo == i_EORSR ||
 					dp->mnemo == i_RTD) {
-					// don't try to test all 65536 possibilies..
+					// don't try to test all 65536 possibilities..
 					uae_u16 i16 = imm16_cnt;
 					put_word_test(pc, imm16_cnt);
 					imm16_cnt += rand16() & 127;

--- a/cputest/cputestgen.ini
+++ b/cputest/cputestgen.ini
@@ -153,7 +153,7 @@ feature_min_interrupt_mask=0
 ; Uses serial port to generate timing interrupt. Requires serial port TX connected to RX.
 ; Generates multiple extra tests.
 ; Used delay instruction: ROL.L D0,D0 (D0 = number of CPU clocks * 2)
-; All test rounds that generate interrupt immediately before or immediately after test instuction
+; All test rounds that generate interrupt immediately before or immediately after test instruction
 ; has been executed are stored. Amiga only.
 feature_interrupts=0
 

--- a/include/uae/types.h
+++ b/include/uae/types.h
@@ -51,7 +51,7 @@ typedef __uint128_t uae_u128;
 #endif
 
 /* Use uaecptr to represent 32-bit (or 24-bit) addresses into the Amiga
- * address space. This is a 32-bit unsigned int regarless of host arch. */
+ * address space. This is a 32-bit unsigned int regardless of host arch. */
 
 typedef uae_u32 uaecptr;
 

--- a/jit/compemu_support.cpp
+++ b/jit/compemu_support.cpp
@@ -1259,7 +1259,7 @@ static void ru_fill_ea(regusage *ru, int reg, amodes mode,
 		ru_set(write_mode ? &ru->wmask : &ru->rmask, reg);
 		break;
 	case Ad16:
-		/* skip displacment */
+		/* skip displacement */
 		m68k_pc_offset += 2;
 	case Aind:
 	case Aipi:

--- a/newcpu.cpp
+++ b/newcpu.cpp
@@ -9462,7 +9462,7 @@ void put_word_cache_040(uaecptr addr, uae_u32 v)
 }
 void put_byte_cache_040(uaecptr addr, uae_u32 v)
 {
-	return write_dcache040(addr, v, 0, dcache_bput);
+	write_dcache040(addr, v, 0, dcache_bput);
 }
 
 uae_u32 get_long_cache_040(uaecptr addr)


### PR DESCRIPTION
Two small cosmetic patches, one to fix some typos, and one to fix some compiler warnings about 'void' functions returning a value.