### PR TITLE
Update A4000(T) TOD source

### DIFF
--- a/cfgfile.cpp
+++ b/cfgfile.cpp
@@ -8697,7 +8697,6 @@ static int bip_a4000 (struct uae_prefs *p, int config, int compa, int romcheck)
 	p->cpu_idle = 150;
 	p->cs_compatible = CP_A4000;
 	built_in_chipset_prefs (p);
-	p->cs_ciaatod = p->ntscmode ? 2 : 1;
 	return configure_rom (p, roms, romcheck);
 }
 static int bip_a4000t (struct uae_prefs *p, int config, int compa, int romcheck)
@@ -8731,7 +8730,6 @@ static int bip_a4000t (struct uae_prefs *p, int config, int compa, int romcheck)
 	p->cpu_idle = 150;
 	p->cs_compatible = CP_A4000T;
 	built_in_chipset_prefs (p);
-	p->cs_ciaatod = p->ntscmode ? 2 : 1;
 	return configure_rom (p, roms, romcheck);
 }
 

--- a/cfgfile.cpp
+++ b/cfgfile.cpp
@@ -9456,6 +9456,7 @@ int built_in_chipset_prefs (struct uae_prefs *p)
 		p->cs_mbdmac = 0;
 		p->cs_ksmirror_a8 = 0;
 		p->cs_ksmirror_e0 = 0;
+		p->cs_ciaatod = p->ntscmode ? 2 : 1;
 		p->cs_z3autoconfig = true;
 		p->cs_unmapped_space = 1;
 		p->cs_eclocksync = 2;
@@ -9468,6 +9469,7 @@ int built_in_chipset_prefs (struct uae_prefs *p)
 		p->cs_mbdmac = 2;
 		p->cs_ksmirror_a8 = 0;
 		p->cs_ksmirror_e0 = 0;
+		p->cs_ciaatod = p->ntscmode ? 2 : 1;
 		p->cs_z3autoconfig = true;
 		p->cs_unmapped_space = 1;
 		p->cs_eclocksync = 2;

--- a/cfgfile.cpp
+++ b/cfgfile.cpp
@@ -9456,7 +9456,6 @@ int built_in_chipset_prefs (struct uae_prefs *p)
 		p->cs_mbdmac = 0;
 		p->cs_ksmirror_a8 = 0;
 		p->cs_ksmirror_e0 = 0;
-		p->cs_ciaatod = p->ntscmode ? 2 : 1;
 		p->cs_z3autoconfig = true;
 		p->cs_unmapped_space = 1;
 		p->cs_eclocksync = 2;
@@ -9469,7 +9468,6 @@ int built_in_chipset_prefs (struct uae_prefs *p)
 		p->cs_mbdmac = 2;
 		p->cs_ksmirror_a8 = 0;
 		p->cs_ksmirror_e0 = 0;
-		p->cs_ciaatod = p->ntscmode ? 2 : 1;
 		p->cs_z3autoconfig = true;
 		p->cs_unmapped_space = 1;
 		p->cs_eclocksync = 2;


### PR DESCRIPTION
Updates "bip_a4000()" to be consistent with "built_in_chipset_prefs()" so VSync TOD source is always used for A4000/A4000T.