### PR TITLE
Use nvram path

### DIFF
--- a/cfgfile.cpp
+++ b/cfgfile.cpp
@@ -8798,7 +8798,7 @@ static int bip_cdtvcr (struct uae_prefs *p, int config, int compa, int romcheck)
 	set_68000_compa (p, compa);
 	p->cs_compatible = CP_CDTVCR;
 	built_in_chipset_prefs (p);
-	fetch_datapath (p->flashfile, sizeof (p->flashfile) / sizeof (TCHAR));
+	fetch_nvrampath(p->flashfile, sizeof (p->flashfile) / sizeof (TCHAR));
 	_tcscat (p->flashfile, _T("cdtv-cr.nvr"));
 	roms[0] = 9;
 	roms[1] = 10;
@@ -8836,7 +8836,7 @@ static int bip_cdtv (struct uae_prefs *p, int config, int compa, int romcheck)
 	set_68000_compa (p, compa);
 	p->cs_compatible = CP_CDTV;
 	built_in_chipset_prefs (p);
-	fetch_datapath (p->flashfile, sizeof (p->flashfile) / sizeof (TCHAR));
+	fetch_nvrampath(p->flashfile, sizeof (p->flashfile) / sizeof (TCHAR));
 	_tcscat (p->flashfile, _T("cdtv.nvr"));
 	roms[0] = 6;
 	roms[1] = 32;
@@ -8865,7 +8865,7 @@ static int bip_cd32 (struct uae_prefs *p, int config, int compa, int romcheck)
 	set_68020_compa (p, compa, 1);
 	p->cs_compatible = CP_CD32;
 	built_in_chipset_prefs (p);
-	fetch_datapath (p->flashfile, sizeof (p->flashfile) / sizeof (TCHAR));
+	fetch_nvrampath(p->flashfile, sizeof (p->flashfile) / sizeof (TCHAR));
 	_tcscat (p->flashfile, _T("cd32.nvr"));
 	roms[0] = 64;
 	roms[1] = -1;
@@ -8887,7 +8887,7 @@ static int bip_cd32 (struct uae_prefs *p, int config, int compa, int romcheck)
 			return 0;
 	} else if (config > 1) {
 		addbcromtype(p, ROMTYPE_CUBO, true, NULL, 0);
-		fetch_datapath(p->flashfile, sizeof(p->flashfile) / sizeof(TCHAR));
+		fetch_nvrampath(p->flashfile, sizeof(p->flashfile) / sizeof(TCHAR));
 		_tcscat(p->flashfile, _T("cd32cubo.nvr"));
 	}
 	return 1;


### PR DESCRIPTION
The new NVRAM path wasn't actually used in CD32/CDTV etc. configs, as they were still fetching the `data` path for the flashfile, instead.

This commit fixes that and sets those configs that have a flashfile, to use the nvram path for it instead.