### PR TITLE
bugfix: loop for ortgmem_type should be for the number of MAX_RTG_BOARDS

### DIFF
--- a/od-win32/mman.cpp
+++ b/od-win32/mman.cpp
@@ -614,7 +614,7 @@ void free_shm (void)
 {
 	resetmem (true);
 	clear_shm ();
-	for (int i = 0; i < MAX_RAM_BOARDS; i++) {
+	for (int i = 0; i < MAX_RTG_BOARDS; i++) {
 		ortgmem_type[i] = -1;
 	}
 }


### PR DESCRIPTION
ortgmem_type is defined having a size of MAX_RTG_BOARDS, but the loop uses MAX_RAM_BOARDS when going through it.

Since MAX_RAM_BOARDS and MAX_RTG_BOARDS happen to be the same (4) in WinUAE, it didn't have any effect. However, if those happen to be different (like in Amiberry, where MAX_RTG_BOARDS is set to 1), then this will cause undefined behavior after the first iteration.