### PR TITLE
Added workaround for Wine RawInput keyboard handling

### DIFF
--- a/od-win32/dinput.cpp
+++ b/od-win32/dinput.cpp
@@ -17,6 +17,7 @@ int tablet_log = 0;
 int no_rawinput = 0;
 int no_directinput = 0;
 int no_windowsmouse = 0;
+int winekeyboard = 0;
 
 #define _WIN32_WINNT 0x501 /* enable RAWINPUT support */
 
@@ -2470,7 +2471,9 @@ static void handle_rawinput_2 (RAWINPUT *raw, LPARAM lParam)
 				write_log (_T("VK->CODE: %x\n"), scancode);
 
 		}
-		if (rk->VKey == 0xff || (rk->Flags & RI_KEY_E0))
+		if (rk->VKey == 0xff || ((rk->Flags & RI_KEY_E0) && !(winekeyboard && rk->VKey == VK_NUMLOCK)))
+			scancode |= 0x80;
+		if (winekeyboard && rk->VKey == VK_PAUSE)
 			scancode |= 0x80;
 		if (rk->MakeCode == KEYBOARD_OVERRUN_MAKE_CODE)
 			return;

--- a/od-win32/win32.cpp
+++ b/od-win32/win32.cpp
@@ -114,7 +114,7 @@ const static GUID GUID_DEVINTERFACE_MOUSE = { 0x378de44c, 0x56ef, 0x11d1,
 { 0xbc, 0x8c, 0x00, 0xa0, 0xc9, 0x14, 0x05, 0xdd } };
 
 extern int harddrive_dangerous, do_rdbdump;
-extern int no_rawinput, no_directinput, no_windowsmouse;
+extern int no_rawinput, no_directinput, no_windowsmouse, winekeyboard;
 extern int force_directsound;
 extern int log_a2065, a2065_promiscuous, log_ethernet;
 extern int rawinput_enabled_hid, rawinput_log;
@@ -6427,6 +6427,10 @@ static int parseargs(const TCHAR *argx, const TCHAR *np, const TCHAR *np2)
 	}
 	if (!_tcscmp(arg, _T("nowindowsmouse"))) {
 		no_windowsmouse = 1;
+		return 1;
+	}
+	if (!_tcscmp(arg, _T("winekeyboard"))) {
+		winekeyboard = 1;
 		return 1;
 	}
 	if (!_tcscmp(arg, _T("rawhid"))) {


### PR DESCRIPTION
Added command line option "-winekeyboard" to change handling of PAUSE and NUMLOCK keys as a workaround for different (buggy?) Wine RawInput key codes and flags.