### PR TITLE
Fix debugger buffer underflow.

### DIFF
--- a/od-win32/debug_win32.cpp
+++ b/od-win32/debug_win32.cpp
@@ -241,7 +241,7 @@ void WriteOutput(const TCHAR *out, int len)
 	for(;;) {
 		p = _tcschr(tmp, '\n');
 		if (p) {
-			pos = addrdiff(p, tmp + 1);
+			pos = addrdiff(p + 1, tmp);
 			if (pos > (MAX_LINEWIDTH + 1))
 				pos = MAX_LINEWIDTH + 1;
 			buf = xcalloc(TCHAR, pos + 2);


### PR DESCRIPTION
- Pivot adjust to fix crash.  Precedence order matters more with the new addrdiff() macro.