### PR TITLE
Fix buffer overflow if VPOS out of range

### DIFF
--- a/debug.cpp
+++ b/debug.cpp
@@ -2219,6 +2219,8 @@ struct dma_rec *last_dma_rec;
 void record_dma_read_value_pos(uae_u32 v, int hpos, int vpos)
 {
 	hpos += dma_record_hoffset;
+	if (hpos >= NR_DMA_REC_HPOS || vpos >= NR_DMA_REC_VPOS)
+		return;	
 	struct dma_rec *dr = &dma_record[dma_record_toggle][vpos * NR_DMA_REC_HPOS + hpos];
 	last_dma_rec = dr;
 	record_dma_read_value(v);


### PR DESCRIPTION
Amiga crash may cause vsync to be lost, causing dma_record[] overflow.