### PR TITLE
ATAPI Write / Mode Select fix

### DIFF
--- a/ide.cpp
+++ b/ide.cpp
@@ -956,9 +956,9 @@ static void do_process_packet_command (struct ide_hdf *ide)
 				ide->intdrq = true;
 			} else {
 				if (IDE_LOG > 1)
-					write_log(_T("IDE%d ATAPI write finished, %d bytes\n"), ide->num, ide->data_size);
-				memcpy (&ide->scsi->buffer, ide->secbuf, ide->data_size);
-				ide->scsi->data_len = ide->data_size;
+					write_log(_T("IDE%d ATAPI write finished, %d bytes\n"), ide->num, ide->packet_data_size);
+				memcpy (ide->scsi->buffer, ide->secbuf, ide->packet_data_size);
+				ide->scsi->data_len = ide->packet_data_size;
 				scsi_emulate_cmd (ide->scsi);
 			}
 		}

--- a/scsi.cpp
+++ b/scsi.cpp
@@ -238,6 +238,15 @@ bool scsi_emulate_analyze (struct scsi_data *sd)
 			sd->direction = 0;
 		}
 		return true;
+	case 0x15: // MODE SELECT (6)
+	case 0x55: // MODE SELECT (10)
+		if (cmd_len == 6) {
+			data_len = sd->cmd[4];
+		} else {
+			data_len = (sd->cmd[7] << 8) | sd->cmd[8];
+		}
+		scsi_grow_buffer(sd, data_len);
+	break;
 	}
 	if (data_len < 0) {
 		if (cmd_len == 6) {


### PR DESCRIPTION
I noticed that setting the volume via mode select on ATAPI devices was not working and tracked it down to this.

Before ```scsi_emulate_cmd()``` is called for commands writing to the device the memcpy was using ```ide->data_size```.
Then ```ide->data_size``` is copied to ```scsi->data_len```.

The problem here is that by the time we get here, ```ide->data_size``` is 0 because it is decremented on every data write before the packet is processed here:
https://github.com/tonioni/WinUAE/blob/b2877eeb48e2a922f2a9ca50481e7d3ca16d0f5c/ide.cpp#L1365-L1373

```ide->data_offset``` is zeroed by ```atapi_set_size()``` well before the call to ```scsi_emulate_cmd()```
https://github.com/tonioni/WinUAE/blob/b2877eeb48e2a922f2a9ca50481e7d3ca16d0f5c/ide.cpp#L857-L861

So I thought ```ide->packet_data_size``` might be the only valid option here.

I then needed to add ```MODE SELECT``` into ```scsi_emulate_analyze()``` to set the correct data_len before this would work.

I noticed that near the bottom of this function, the data_len will be set from the usual location in the CDB but only if data_len was already -1.
I wonder if it might make sense to set ```scsi->data_len``` to -1 before the call to ```scsi_emualate_analyze()``` but wasn't sure.