### PR TITLE
GitHub Actions workflow to build WinUAE binary on demand

### DIFF
--- a/.github/workflows/build-winuae-binary.yaml
+++ b/.github/workflows/build-winuae-binary.yaml
@@ -1,0 +1,73 @@
+name: Build WinUAE binary
+
+on:
+  workflow_dispatch:
+    inputs:
+      Configuration:
+        descripion: "Type of binary build"
+        required: true
+        default: "Test"
+        type: choice
+        options:
+        - Release
+        - Test
+        - FullRelease
+      Platform:
+        description: "Platform to build for"
+        required: true
+        default: "Win32"
+        type: choice
+        options:
+        - Win32
+        - x64
+
+env:
+  SOLUTION_FILE_PATH: od-win32\\winuae_msvc15
+
+jobs:
+  Build-WinUAE-binary:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2.0.0
+
+    # Running roughly step 4 of README.md
+    - name: Download WinUAE includes and libs
+      shell: powershell
+      run: Invoke-WebRequest -Uri "https://download.abime.net/winuae/files/b/winuaeinclibs.zip" -OutFile "winuaeinclibs.zip"
+
+    - name: Unpack WinUAE includes and libs to C:\\dev
+      uses: ihiroky/extract-action@v1
+      with:
+        file_path: winuaeinclibs.zip
+        extract_dir: C:\\dev
+
+    # Running roughly step 6 of README.md
+    - name: Download AROS ROM cpp
+      shell: powershell
+      run: Invoke-WebRequest -Uri "https://download.abime.net/winuae/files/b/aros.rom.cpp.zip" -OutFile "aros.rom.cpp.zip"
+
+    - name: Unpack AROS ROM cpp
+      uses: ihiroky/extract-action@v1
+      with:
+        file_path: aros.rom.cpp.zip
+        extract_dir: .
+
+    # Running roughly step 7 of README.md
+    - name: Add NASM to PATH
+      uses: ilammy/setup-nasm@v1.5.1
+
+    # Running roughly step 12 of README.md
+    - name: Build ${{ inputs.Platform }} ${{ inputs.Configuration }}
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Platform=${{ inputs.Platform }} /p:Configuration=${{ inputs.Configuration }} ${{env.SOLUTION_FILE_PATH}}
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: WinUAE ${{ inputs.Platform }} ${{ inputs.Configuration }}
+        path: D:\\Amiga


### PR DESCRIPTION
It seems like it's surprisingly easy to build WinUAE per GitHub action!

After merge, you'll be able to
- go to https://github.com/tonioni/WinUAE/actions
- select "Build WinUAE binary" on the left hand side
- select "Run workflow" on the right
- pick a Release / Test / FullRelease build
- pick a Win32 or x64 build
- click "Run Workflow"
to trigger a build, which will result in a ZIP-File with a winuae.exe or winuae64.exe at the end of it.

This makes at least my life _so_ much easier (and can be configured to run on push on branch ...) ...