### PR TITLE
Clear memory breakpoints if quitting from the debugger

### DIFF
--- a/debug.cpp
+++ b/debug.cpp
@@ -6821,6 +6821,7 @@ static bool debug_line (TCHAR *input)
 			break;
 
 		case 'q':
+			deinitialize_memwatch();
 			uae_quit();
 			deactivate_debugger();
 			return true;


### PR DESCRIPTION
uae_quit() doesn't instantly exit, but sets a flag to exit soon. This flag is checked at regular intervals (I believe)  If a memory breakpoint is hit before the flag is checked, the debugger opens up rather than quitting gracefully. By calling deinitialize_memwatch(), the memory breakpoints won't cause problems. Not sure if this is also a problem with code breakpoints as well, but if it is then my code doesn't fix that

deinitialize_memwatch() could maybe be called from within uae_quit, but I'm not confident in the side effects hence the simplest solution.