### PR TITLE
addrbank gcc compatibility fix in include/memory.h

### DIFF
--- a/include/memory.h
+++ b/include/memory.h
@@ -111,7 +111,7 @@ enum
 #define ABFLAG_CACHE_ENABLE_BOTH (ABFLAG_CACHE_ENABLE_DATA | ABFLAG_CACHE_ENABLE_INS)
 #define ABFLAG_CACHE_ENABLE_ALL (ABFLAG_CACHE_ENABLE_BOTH | ABFLAG_CACHE_ENABLE_INS_BURST | ABFLAG_CACHE_ENABLE_DATA_BURST)
 
-typedef struct {
+typedef struct addrbank {
 	/* These ones should be self-explanatory...
 	 * Do not move. JIT depends on it
 	 */
@@ -181,7 +181,7 @@ struct autoconfig_info
 	// never direct maps RAM
 	bool indirect;
 	const TCHAR *label;
-	addrbank *addrbank;
+	struct addrbank *addrbank;
 	uaecptr write_bank_address;
 	struct romconfig *rc;
 	uae_u32 last_high_ram;


### PR DESCRIPTION
GCC does not accept the same identifier used as both type and variable name "addrbank *addrbank;". Changing to struct addrbank fixes this (alternative fix is to change the type name to something like addrbank_t). I've tested that WinUAE builds fine with this change.