### PR TITLE
GCC compatibility fixes for a2091

### DIFF
--- a/a2091.cpp
+++ b/a2091.cpp
@@ -1398,7 +1398,7 @@ static void wd_cmd_reset (struct wd_chip_state *wd, bool irq, bool fast)
 	wd->wd_selected = false;
 	wd->scsi = NULL;
 	for (int j = 0; j < WD_STATUS_QUEUE; j++) {
-		memset(&wd->status[j], 0, sizeof status_data);
+		memset(&wd->status[j], 0, sizeof(status_data));
 	}
 	wd->queue_index = 0;
 	wd->auxstatus = 0;
@@ -1461,7 +1461,7 @@ static void wd_check_interrupt(struct wd_state *wds, bool checkonly)
 		wd->wd_busy = false;
 		if (wd->queue_index == 2) {
 			wd->status[0].irq = 1;
-			memcpy(&wd->status[0], &wd->status[1], sizeof status_data);
+			memcpy(&wd->status[0], &wd->status[1], sizeof(status_data));
 			wd->queue_index = 1;
 		} else {
 			wd->queue_index = 0;
@@ -1711,7 +1711,7 @@ uae_u8 wdscsi_get (struct wd_chip_state *wd, struct wd_state *wds)
 	return v;
 }
 
-uae_u8 wdscsi_get_data(struct wd_chip_state *wd, struct wd_state *wds)
+static uae_u8 wdscsi_get_data(struct wd_chip_state *wd, struct wd_state *wds)
 {
 	uae_u8 sasr = wd->sasr;
 	wd->sasr = WD_DATA;
@@ -2588,8 +2588,6 @@ static void REGPARAM2 dmac_a2091_wput(struct wd_state *wd, uaecptr addr, uae_u32
 	dmac_a2091_write_word(wd, addr, w);
 }
 
-extern const addrbank dmaca2091_bank;
-
 static void REGPARAM2 dmac_a2091_bput(struct wd_state *wd, uaecptr addr, uae_u32 b)
 {
 	b &= 0xff;
@@ -2931,8 +2929,6 @@ static void REGPARAM2 comspec_wput(struct wd_state *wd, uaecptr addr, uae_u32 w)
 	comspec_write_word(wd, addr, w);
 }
 
-extern const addrbank dmaca2091_bank;
-
 static void REGPARAM2 comspec_bput(struct wd_state *wd, uaecptr addr, uae_u32 b)
 {
 	b &= 0xff;
@@ -3057,8 +3053,6 @@ static const addrbank comspec_bank = {
 
 
 /* GVP Series I and II */
-
-extern const addrbank gvp_bank;
 
 static uae_u32 dmac_gvp_read_byte(struct wd_state *wd, uaecptr addr)
 {
@@ -4129,7 +4123,7 @@ bool a2091_init (struct autoconfig_info *aci)
 	wd->configured = 0;
 	wd->autoconfig = true;
 	wd->board_mask = 65535;
-	memcpy(&wd->bank, &dmaca2091_bank, sizeof addrbank);
+	memcpy(&wd->bank, &dmaca2091_bank, sizeof(addrbank));
 	memcpy(wd->dmacmemory, aci->autoconfig_raw, sizeof wd->dmacmemory);
 
 	alloc_expansion_bank(&wd->bank, aci);
@@ -4216,7 +4210,7 @@ static bool a2090x_init (struct autoconfig_info *aci, bool combitec)
 	wd->configured = 0;
 	wd->autoconfig = true;
 	wd->board_mask = 65535;
-	memcpy(&wd->bank, &dmaca2091_bank, sizeof addrbank);
+	memcpy(&wd->bank, &dmaca2091_bank, sizeof(addrbank));
 	memcpy(wd->dmacmemory, aci->autoconfig_raw, sizeof wd->dmacmemory);
 
 	alloc_expansion_bank(&wd->bank, aci);
@@ -4259,7 +4253,7 @@ bool a2090b_preinit (struct autoconfig_info *aci)
 	struct wd_state *wd = getscsi(aci->rc);
 	if (!wd)
 		return false;
-	memcpy(&wd->bank2, &combitec_bank, sizeof addrbank);
+	memcpy(&wd->bank2, &combitec_bank, sizeof(addrbank));
 	wd->bank2.start = 0xf10000;
 	wd->bank2.reserved_size = 0x10000;
 	wd->bank2.mask = 0xffff;
@@ -4367,7 +4361,7 @@ static bool gvp_init(struct autoconfig_info *aci, bool series2, bool accel, uae_
 	init_wd_scsi(wd, aci->rc->dma24bit);
 	wd->configured = 0;
 	wd->threaded = true;
-	memcpy(&wd->bank, &gvp_bank, sizeof addrbank);
+	memcpy(&wd->bank, &gvp_bank, sizeof(addrbank));
 	wd->autoconfig = true;
 	wd->rombankswitcher = 0;
 	memset(wd->dmacmemory, 0xff, sizeof wd->dmacmemory);
@@ -4550,7 +4544,7 @@ bool comspec_preinit (struct autoconfig_info *aci)
 	wd->autoconfig = true;
 	wd->board_mask = 65535;
 	wd->wc.resetnodelay = true;
-	memcpy(&wd->bank, &comspec_bank, sizeof addrbank);
+	memcpy(&wd->bank, &comspec_bank, sizeof(addrbank));
 	memcpy(wd->dmacmemory, aci->autoconfig_raw, sizeof wd->dmacmemory);
 
 	alloc_expansion_bank(&wd->bank, aci);

--- a/cpuboard.cpp
+++ b/cpuboard.cpp
@@ -37,6 +37,7 @@
 #include "scsi.h"
 #include "cpummu030.h"
 #include "devices.h"
+#include "a2091.h"
 
 // ROM expansion board diagrom call
 // 00F83B7C 3.1 A4000
@@ -1544,7 +1545,6 @@ static void REGPARAM2 blizzardio_wput(uaecptr addr, uae_u32 v)
 			cpu_fallback(0);
 		}
 	} else if (is_a1230s2(&currprefs)) {
-		extern void gvp_accelerator_set_dma_bank(uae_u8);
 		io_reg[0] = v & 0xff;
 		gvp_accelerator_set_dma_bank((v >> 4) & 3);
 	}

--- a/include/a2091.h
+++ b/include/a2091.h
@@ -1,6 +1,8 @@
 #ifndef UAE_A2091_H
 #define UAE_A2091_H
 
+#include "commpipe.h"
+
 #ifdef A2091
 
 #define WD_STATUS_QUEUE 2

--- a/include/a2091.h
+++ b/include/a2091.h
@@ -169,6 +169,8 @@ extern int add_wd_scsi_hd (struct wd_state *wd, int ch, struct hd_hardfiledata *
 extern int add_wd_scsi_cd (struct wd_state *wd, int ch, int unitnum);
 extern int add_wd_scsi_tape (struct wd_state *wd, int ch, const TCHAR *tape_directory, bool readonly);
 
+void gvp_accelerator_set_dma_bank(uae_u8);
+
 #endif /* A2091 */
 
 #endif /* UAE_A2091_H */

--- a/include/commpipe.h
+++ b/include/commpipe.h
@@ -10,6 +10,7 @@
 #define UAE_COMMPIPE_H
 
 #include "uae/types.h"
+#include "threaddep/thread.h"
 
 typedef union {
 	int i;

--- a/od-win32/threaddep/thread.h
+++ b/od-win32/threaddep/thread.h
@@ -1,3 +1,6 @@
+#ifndef THREADDEP_THREAD_H
+#define THREADDEP_THREAD_H
+
 typedef HANDLE uae_sem_t;
 typedef HANDLE uae_thread_id;
 
@@ -21,3 +24,5 @@ STATIC_INLINE void uae_wait_thread(uae_thread_id tid)
     WaitForSingleObject (tid, INFINITE);
     CloseHandle (tid);
 }
+
+#endif /* THREADDEP_THREAD_H */


### PR DESCRIPTION
Added () to sizeof where necessary, moved one function declaration to header file, made minor changes to a couple of header files so a2091.h can be included by cpuboard.cpp.