### PR TITLE
cdtv: rename checkint to cdtv_checkint, some static attribute fixes

### DIFF
--- a/cd32_fmv.cpp
+++ b/cd32_fmv.cpp
@@ -1385,7 +1385,7 @@ static void fmv_next_cd_audio_buffer_callback(int bufnum, void *param)
 	uae_sem_post(&play_sem);
 }
 
-void cd32_fmv_vsync_handler(void)
+static void cd32_fmv_vsync_handler(void)
 {
 }
 

--- a/cdtv.cpp
+++ b/cdtv.cpp
@@ -1142,7 +1142,7 @@ void cdtv_getdmadata (uae_u32 *acr)
 	*acr = dmac_acr;
 }
 
-static void checkint (void)
+static void cdtv_checkint(void)
 {
 	int irq = 0;
 #ifdef A2091
@@ -1160,7 +1160,7 @@ static void checkint (void)
 
 void cdtv_scsi_int (void)
 {
-	checkint ();
+	cdtv_checkint();
 }
 void cdtv_scsi_clear_int (void)
 {
@@ -1169,7 +1169,7 @@ void cdtv_scsi_clear_int (void)
 
 static void rethink_cdtv (void)
 {
-	checkint ();
+	cdtv_checkint();
 	tp_check_interrupts ();
 }
 
@@ -1195,7 +1195,7 @@ static void CDTV_hsync_handler (void)
 		dma_finished = 0;
 		cdtv_hsync = -1;
 	}
-	checkint ();
+	cdtv_checkint();
 
 	if (cdrom_command_done) {
 		cdrom_command_done = 0;
@@ -1349,7 +1349,7 @@ static uae_u32 dmac_bget2 (uaecptr addr)
 #ifdef A2091
 		if (cdtvscsi) {
 			v = wdscsi_get (&wd_cdtv->wc, wd_cdtv);
-			checkint ();
+			cdtv_checkint();
 		}
 #endif
 		break;
@@ -1454,7 +1454,7 @@ static void dmac_bput2 (uaecptr addr, uae_u32 b)
 #ifdef A2091
 		if (cdtvscsi) {
 			wdscsi_sasr (&wd_cdtv->wc, b);
-			checkint ();
+			cdtv_checkint();
 		}
 #endif
 		break;
@@ -1462,7 +1462,7 @@ static void dmac_bput2 (uaecptr addr, uae_u32 b)
 #ifdef A2091
 		if (cdtvscsi) {
 			wdscsi_put (&wd_cdtv->wc, wd_cdtv, b);
-			checkint ();
+			cdtv_checkint();
 		}
 #endif
 		break;
@@ -1487,7 +1487,7 @@ static void dmac_bput2 (uaecptr addr, uae_u32 b)
 	case 0xe4:
 	case 0xe5:
 		dmac_istr = 0;
-		checkint ();
+		cdtv_checkint();
 		break;
 	case 0xe8:
 	case 0xe9:
@@ -1714,7 +1714,7 @@ uae_u8 cdtv_battram_read (int addr)
 
 MEMORY_FUNCTIONS(cardmem);
 
-static addrbank cardmem_bank = {
+addrbank cardmem_bank = {
 	cardmem_lget, cardmem_wget, cardmem_bget,
 	cardmem_lput, cardmem_wput, cardmem_bput,
 	cardmem_xlate, cardmem_check, NULL, _T("rom_e0"), _T("CDTV memory card"),


### PR DESCRIPTION
- cdtv: rename checkint to cdtv_checkint to avoid conflict new checkint in newcpu
- added and removed a couple of static modifiers
