### PR TITLE
framebufferboards: use DECLARE_MEMORY_FUNCTIONS and move definition up

### DIFF
--- a/framebufferboards.cpp
+++ b/framebufferboards.cpp
@@ -24,7 +24,16 @@
 typedef uae_u32(REGPARAM3 *fb_get_func)(struct fb_struct *, uaecptr) REGPARAM;
 typedef void (REGPARAM3 *fb_put_func)(struct fb_struct *, uaecptr, uae_u32) REGPARAM;
 
-extern addrbank generic_fb_bank;
+DECLARE_MEMORY_FUNCTIONS(fb);
+
+static addrbank generic_fb_bank
+{
+	fb_lget, fb_wget, fb_bget,
+	fb_lput, fb_wput, fb_bput,
+	default_xlate, default_check, NULL, NULL, _T("FRAMEBUFFER BOARD"),
+	fb_lget, fb_wget,
+	ABFLAG_IO, S_READ, S_WRITE
+};
 
 struct fb_struct
 {
@@ -708,15 +717,6 @@ static uae_u32 REGPARAM2 fb_lget(uaecptr addr)
 	}
 	return v;
 }
-
-static addrbank generic_fb_bank
-{
-	fb_lget, fb_wget, fb_bget,
-	fb_lput, fb_wput, fb_bput,
-	default_xlate, default_check, NULL, NULL, _T("FRAMEBUFFER BOARD"),
-	fb_lget, fb_wget,
-	ABFLAG_IO, S_READ, S_WRITE
-};
 
 struct gfxboard_func harlequin_func
 {


### PR DESCRIPTION
generic_fb_bank is unchanged, only moved further up to be able to remove the (at least for non-msvc compilers) incompatible extern declaration.