### PR TITLE
Fix overlapping _tcscpy write

### DIFF
--- a/disk.cpp
+++ b/disk.cpp
@@ -1406,7 +1406,9 @@ static int drive_insert (drive *drv, struct uae_prefs *p, int dnum, const TCHAR 
 		_tcsncpy (changed_prefs.floppyslots[dnum].df, fname_in, 255);
 		changed_prefs.floppyslots[dnum].df[255] = 0;
 		changed_prefs.floppyslots[dnum].forcedwriteprotect = forcedwriteprotect;
-		_tcscpy (drv->newname, fname_in);
+		if (drv->newname != fname_in) {
+			_tcscpy(drv->newname, fname_in);
+		}
 		drv->newnamewriteprotected = forcedwriteprotect;
 		gui_filename (dnum, outname);
 	}


### PR DESCRIPTION
When drive_insert is called from DISK_hsync, it is called with drv->newname as fname_in, causing invokation of _tcscpy with the same src and dst address (overlapping write), which may or may not be a problem, but it least isn't allowed (undefined behavior).

(Discovered by valgrind memchecker while debugging another problem)