### PR TITLE
uae_s64 int -> uae_s64

### DIFF
--- a/od-win32/fsdb_mywin32.cpp
+++ b/od-win32/fsdb_mywin32.cpp
@@ -253,7 +253,7 @@ void my_close (struct my_openfile_s *mos)
 	xfree (mos);
 }
 
-uae_s64 int my_lseek (struct my_openfile_s *mos, uae_s64 int offset, int whence)
+uae_s64 my_lseek(struct my_openfile_s *mos, uae_s64 offset, int whence)
 {
 	LARGE_INTEGER li, old;
 
@@ -270,7 +270,7 @@ uae_s64 int my_lseek (struct my_openfile_s *mos, uae_s64 int offset, int whence)
 		return -1;
 	return old.QuadPart;
 }
-uae_s64 int my_fsize (struct my_openfile_s *mos)
+uae_s64 my_fsize(struct my_openfile_s *mos)
 {
 	LARGE_INTEGER li;
 	if (!GetFileSizeEx (mos->h, &li))


### PR DESCRIPTION
As it is, it accidentially works when uae_s64 is #defined as long long, but not if it is typedef'ed to e.g. int64_t.