### PR TITLE
zfile: Free the current list item, not the next (+ two minor fixes)

### DIFF
--- a/include/zfile.h
+++ b/include/zfile.h
@@ -1,5 +1,4 @@
  /*
- /*
   * UAE - The Un*x Amiga Emulator
   *
   * routines to handle compressed file automatically

--- a/zfile.cpp
+++ b/zfile.cpp
@@ -138,7 +138,7 @@ static void zcache_close (void)
 	while (zc) {
 		struct zcache *n = zc->next;
 		zcache_free_data (zc);
-		xfree (n);
+		xfree(zc);
 		zc = n;
 	}
 }
@@ -1788,7 +1788,7 @@ static struct zfile *zfile_fopen_x (const TCHAR *name, const TCHAR *mode, int ma
 
 	if (_tcslen (name) == 0)
 		return NULL;
-	manglefilename(name, path, sizeof(path) / sizeof TCHAR);
+	manglefilename(name, path, sizeof(path) / sizeof(TCHAR));
 	l = zfile_fopen_2 (path, mode, mask);
 	if (!l)
 		return 0;


### PR DESCRIPTION
In zcache_close, while freeing the linked list, the next item is freed instead of the current one.

(Additionally, adding a sizeof fix + remove double opening /* in header)