### PR TITLE
Fix audio state machine stale intreq2 logic

### DIFF
--- a/audio.cpp
+++ b/audio.cpp
@@ -1813,7 +1813,7 @@ static bool audio_state_channel2 (int nr, bool perfin)
 				cdp->ptx_tofetch = true;
 			cdp->dsr = true;
 			if (cdp->intreq2) {
-				setirq(nr, 00);
+				setirq(nr, 0);
 				cdp->intreq2 = false;
 			}
 #if TEST_AUDIO > 0
@@ -1826,7 +1826,7 @@ static bool audio_state_channel2 (int nr, bool perfin)
 #endif
 		} else if (cdp->dat_written && !isirq (nr)) {
 			cdp->state = 2;
-			setirq(nr, 01);
+			setirq(nr, 1);
 			loaddat(nr);
 			if (usehacks() && cdp->per < 10 * CYCLE_UNIT) {
 				static int warned = 100;


### PR DESCRIPTION
As discussed in the "Undocumented Amiga hardware stuff" thread https://eab.abime.net/showpost.php?p=1679952&postcount=337, the audio state machine intreq2 signal should only be cleared when used to request an interrupt (AUDxIR).

Previously, intreq2 was cleared (and no interrupt requested) on the transition from state 5 to state 2. This made logical sense, but was missing the interrupts. Now, intreq2 is checked on transition from state 0 to state 1. If it is set, then an interrupt is requested and intreq2 is cleared.

The "stale intreq2" interrupts have been shown to be present on silicon using test case https://github.com/dirkwhoffmann/vAmigaTS/blob/master/Paula/Audio/timing/dmatim2/ and with this change, three interrupts that were previously absent in WinUAE are now present in this test case.

This is the [reference image](https://github.com/dirkwhoffmann/vAmigaTS/blob/master/Paula/Audio/timing/dmatim2/dmatim2_A500_ECS.JPG) from the test suite:

![dmatim2_A500_ECS](https://github.com/user-attachments/assets/61a743d6-fa78-40ec-99af-1663fca3124c)

Here are two photos (centering left and right) I took of the ADF running on real hardware: A500 PAL 6A, Fatter Agnus 8372A 318069-02 ECS, Paula version unknown sorry, Kickstart 1.3 34.5, 512 KB trapdoor expansion. The monitor has a little vertical RGB split towards the right sorry.

<img width="1074" height="879" alt="dmatim2_silicon_lhs" src="https://github.com/user-attachments/assets/8e23bb1c-f9d3-4d01-9398-7162fcc399af" />
<img width="1084" height="897" alt="dmatim2_silicon_rhs" src="https://github.com/user-attachments/assets/f241fbd0-ec3a-4508-9c61-3c9bb83159a1" />

WinUAE before this change was missing three interrupts:

<img width="1687" height="890" alt="dmatim2_WinUAE_diff" src="https://github.com/user-attachments/assets/38a4d419-7a2b-4ef3-a7ea-3b43f35f68fe" />

The three new interrupts can be seen in the highlighted diffs:
<img width="1687" height="890" alt="dmatim2_WinUAE_diff_highlight" src="https://github.com/user-attachments/assets/31bcd871-303c-40eb-8415-672c46eb14eb" />

There are some other difference in the images that I can't explain sorry - I should really make myself more familiar with this test suite.

Please let me know if you require any further information.

WinUAE config file: [Config.zip](https://github.com/user-attachments/files/23633685/Config.zip)