### PR TITLE
Fix build warning cleanups

### DIFF
--- a/custom.cpp
+++ b/custom.cpp
@@ -1829,7 +1829,7 @@ void compute_framesync(void)
 		hblank_hz,
 		maxhpos, maxvpos, lof_store ? 1 : 0,
 		cr ? cr->index : -1,
-		cr != NULL && cr->label != NULL ? cr->label : _T("<?>"),
+		cr != nullptr && cr->label[0] != '\0' ? cr->label : _T("<?>"),
 		currprefs.gfx_apmode[ad->picasso_on ? 1 : 0].gfx_display, ad->picasso_on, ad->picasso_requested_on
 	);
 }
@@ -8234,7 +8234,7 @@ uae_u8 *restore_custom_extra(uae_u8 *src)
 	currprefs.cs_denisemodel = changed_prefs.cs_denisemodel = RBB;
 
 	// workaround for old savestates that had A1000 chipset extra with AGA mode configured.
-	if (currprefs.cs_agnusmodel = AGNUSMODEL_A1000 && aga_mode && currprefs.cs_compatible == CP_A1000) {
+	if (currprefs.cs_agnusmodel == AGNUSMODEL_A1000 && aga_mode && currprefs.cs_compatible == CP_A1000) {
 		currprefs.cs_agnusmodel = changed_prefs.cs_agnusmodel = AGNUSMODEL_AGA;
 		currprefs.cs_compatible = changed_prefs.cs_compatible = CP_A1200;
 	}
@@ -10818,9 +10818,7 @@ static int can_fast_custom(void)
 			}
 		}
 	}
-	if (0 || 1)
-		return 1;
-	return 0;
+	return 1;
 }
 
 static void do_imm_dmal(void)

--- a/drawing.cpp
+++ b/drawing.cpp
@@ -1184,7 +1184,7 @@ static bool get_genlock_very_rare_and_complex_case(uae_u8 v)
 			if (v >= 128 && v < 192 && (currprefs.ecs_genlock_features_colorkey_mask[2] & (1LL << (v - 128)))) {
 				return false;
 			}
-			if (v >= 192 && v < 256 && (currprefs.ecs_genlock_features_colorkey_mask[3] & (1LL << (v - 192)))) {
+			if (v >= 192 && (currprefs.ecs_genlock_features_colorkey_mask[3] & (1LL << (v - 192)))) {
 				return false;
 			}
 		} else {
@@ -5691,33 +5691,35 @@ static void get_line(int monid, int gfx_ypos, enum nln_how how, int lol_shift_pr
 		switch (how)
 		{
 			case nln_lower_black_always:
-			if (gfx_ypos + 1 < vb->inheight) {
-				setxlinebuffer(0, gfx_ypos + 1);
-				memset(xlinebuffer, 0, vb->inwidth * vb->pixbytes);
-			}
-			break;
+				if (gfx_ypos + 1 < vb->inheight) {
+					setxlinebuffer(0, gfx_ypos + 1);
+					memset(xlinebuffer, 0, vb->inwidth * vb->pixbytes);
+				}
+				break;
 			case nln_upper_black_always:
-			if (gfx_ypos > 0) {
-				setxlinebuffer(0, gfx_ypos - 1);
-				memset(xlinebuffer, 0, vb->inwidth * vb->pixbytes);
-			}
-			break;
+				if (gfx_ypos > 0) {
+					setxlinebuffer(0, gfx_ypos - 1);
+					memset(xlinebuffer, 0, vb->inwidth * vb->pixbytes);
+				}
+				break;
 			case nln_doubled:
-			if (gfx_ypos + 1 < vb->inheight) {
-				setxlinebuffer(0, gfx_ypos + 1);
-				xlinebuffer2 = xlinebuffer;
-				xlinebuffer2_start = xlinebuffer_start;
-				xlinebuffer2_end = xlinebuffer_end;
-				denise_y_end++;
-			}
-			break;
+				if (gfx_ypos + 1 < vb->inheight) {
+					setxlinebuffer(0, gfx_ypos + 1);
+					xlinebuffer2 = xlinebuffer;
+					xlinebuffer2_start = xlinebuffer_start;
+					xlinebuffer2_end = xlinebuffer_end;
+					denise_y_end++;
+				}
+				break;
 			case nln_nblack:
-			if (gfx_ypos + 1 < vb->inheight) {
-				setxlinebuffer(0, gfx_ypos + 1);
-				memset(xlinebuffer, 0, vb->inwidth * vb->pixbytes);
-				denise_y_end++;
-			}
-			break;
+				if (gfx_ypos + 1 < vb->inheight) {
+					setxlinebuffer(0, gfx_ypos + 1);
+					memset(xlinebuffer, 0, vb->inwidth * vb->pixbytes);
+					denise_y_end++;
+				}
+				break;
+			default:
+				break;
 		}
 		setxlinebuffer(0, gfx_ypos);
 		xshift = linetoscr_x_adjust >> hresolution;

--- a/jit/compemu_support.cpp
+++ b/jit/compemu_support.cpp
@@ -3827,7 +3827,7 @@ void flush_reg(int reg)
 		}
 		Dif (live.state[reg].val && reg!=PC_P)
 		{
-			jit_log("Register %d still has val %x", reg, live.state[reg].val);
+			jit_log("Register %d still has val %llx", reg, (uae_u64)live.state[reg].val);
 		}
 	}
 }

--- a/jit/exception_handler.cpp
+++ b/jit/exception_handler.cpp
@@ -400,7 +400,7 @@ static int handle_access(uintptr_t fault_addr, CONTEXT_T context)
 		return 0;
 	}
 
-	uae_u32 addr = uae_p32(fault_addr) - uae_p32(NATMEM_OFFSET);
+	uae_u32 addr = (uae_u32)(fault_addr - (uintptr_t)NATMEM_OFFSET);
 #ifdef DEBUG_ACCESS
 	if (addr >= 0x80000000) {
 		write_log (_T("JIT: Suspicious address 0x%x in SEGV handler.\n"), addr);
@@ -508,7 +508,7 @@ static int handle_access(uintptr_t fault_addr, CONTEXT_T context)
 		return 0;
 	}
 
-	uae_u32 addr = uae_p32(fault_addr) - uae_p32(NATMEM_OFFSET);
+	uae_u32 addr = (uae_u32)(fault_addr - (uintptr_t)NATMEM_OFFSET);
 #ifdef DEBUG_ACCESS
 	if (addr >= 0x80000000) {
 			write_log (_T("JIT: Suspicious address 0x%x in SEGV handler.\n"), addr);
@@ -600,7 +600,8 @@ LONG WINAPI EvalException(LPEXCEPTION_POINTERS info)
 	}
 	if (currprefs.comp_catchfault) {
 		// setup fake exception
-		exception2_setup(regs.opcode, uae_p32(address) - uae_p32(NATMEM_OFFSET), info->ExceptionRecord->ExceptionInformation[0] == 0, 1, regs.s ? 4 : 0);
+		uae_u32 amiga_addr = (uae_u32)(address - (uintptr_t)NATMEM_OFFSET);
+		exception2_setup(regs.opcode, amiga_addr, info->ExceptionRecord->ExceptionInformation[0] == 0, 1, regs.s ? 4 : 0);
 		return EXCEPTION_EXECUTE_HANDLER;
 	}
 	return EXCEPTION_CONTINUE_SEARCH;

--- a/pcem/vid_voodoo_banshee.cpp
+++ b/pcem/vid_voodoo_banshee.cpp
@@ -1813,9 +1813,10 @@ void banshee_hwcursor_draw(svga_t *svga, int displine)
         {                                                               \
                 int c;                                                  \
                 int wp = 0;                                             \
-                uint32_t base_addr = (buf == banshee->overlay_buffer[1]) ? src_addr2 : src_addr;        \
+                uint32_t *dst = &(buf)[0];                              \
+                uint32_t base_addr = (dst == banshee->overlay_buffer[1]) ? src_addr2 : src_addr; \
                                                                         \
-                for (c = 0; c < voodoo->overlay.overlay_bytes; c += 2) \
+                for (c = 0; c < voodoo->overlay.overlay_bytes; c += 2)  \
                 {                                                       \
                         uint16_t data = *(uint16_t *)&svga->vram[(base_addr + (c & 127) + (c >> 7)*128*32) & svga->vram_mask];               \
                         int r = data & 0x1f;                            \
@@ -1823,9 +1824,9 @@ void banshee_hwcursor_draw(svga_t *svga, int displine)
                         int b = data >> 11;                             \
                                                                         \
                         if (banshee->vidProcCfg & VIDPROCCFG_OVERLAY_CLUT_BYPASS) \
-                                buf[wp++] = (r << 3) | (g << 10) | (b << 19); \
+                                dst[wp++] = (r << 3) | (g << 10) | (b << 19); \
                         else                                            \
-                                buf[wp++] = (clut[r << 3] & 0x0000ff) | \
+                                dst[wp++] = (clut[r << 3] & 0x0000ff) | \
                                             (clut[g << 2] & 0x00ff00) | \
                                             (clut[b << 3] & 0xff0000);  \
                 }                                                       \

--- a/pcem/x86seg.cpp
+++ b/pcem/x86seg.cpp
@@ -181,7 +181,7 @@ void x86gpf(const char *s, uint16_t error)
 void x86gpf_expected(const char *s, uint16_t error)
 {
 //        pclog("GPF_v86 %04X %04x(%08x):%08x\n", error, CS,cs,cpu_state.pc);
-        cpu_state.abrt = ABRT_GPF | ABRT_EXPECTED;
+        cpu_state.abrt = static_cast<int8_t>(ABRT_GPF | ABRT_EXPECTED);
         abrt_error = error;
 }
 void x86ss(char *s, uint16_t error)

--- a/vm.cpp
+++ b/vm.cpp
@@ -235,7 +235,7 @@ static bool do_protect(void *address, int size, int protect)
 #ifdef _WIN32
 	DWORD old;
 	if (VirtualProtect(address, size, protect_to_native(protect), &old) == 0) {
-		uae_log("VM: uae_vm_protect(%p, %d, %d) VirtualProtect failed (%d)\n",
+		uae_log("VM: uae_vm_protect(%p, %d, %d) VirtualProtect failed (%lu)\n",
 				address, size, protect, GetLastError());
 		return false;
 	}


### PR DESCRIPTION
## Summary
- Clean up warning-prone conditions in custom chip and drawing code.
- Fix pointer-width address narrowing in JIT exception handling and Windows error-code format specifiers.
- Avoid comparing a macro argument array expression directly with the Voodoo overlay buffer.
- Cast the expected x86 GPF abort flags explicitly.

## Validation
- `git diff --cached --check` passed before commit.
- `MSBuild.exe od-win32\winuae_msvc15\winuae_msvc.sln /m /p:Configuration=Release /p:Platform=x64 /v:minimal /nologo` compiled the touched sources. The final rebuild no longer reports the fixed `jit\exception_handler.cpp(403/603)` or `pcem\x86seg.cpp(184)` warnings, then fails at link because the local `od-win32\lib\prowizard.lib` is x86 while the target is x64, leaving `prowizard_search` unresolved.