### PR TITLE
archive: make media archive helpers portable

### DIFF
--- a/archivers/chd/chdcodec.cpp
+++ b/archivers/chd/chdcodec.cpp
@@ -1133,15 +1133,25 @@ chd_lzma_decompressor::chd_lzma_decompressor(chd_file &chd, UINT32 hunkbytes, bo
 	CLzmaEncProps encoder_props;
 	chd_lzma_compressor::configure_properties(encoder_props, hunkbytes);
 
-	// convert to decoder properties
-	CLzmaProps decoder_props;
-	decoder_props.lc = encoder_props.lc;
-	decoder_props.lp = encoder_props.lp;
-	decoder_props.pb = encoder_props.pb;
-	decoder_props.dicSize = encoder_props.dictSize;
+	CLzmaEncHandle encoder = LzmaEnc_Create(&m_allocator);
+	if (!encoder)
+		throw CHDERR_DECOMPRESSION_ERROR;
+	if (LzmaEnc_SetProps(encoder, &encoder_props) != SZ_OK)
+	{
+		LzmaEnc_Destroy(encoder, &m_allocator, &m_allocator);
+		throw CHDERR_DECOMPRESSION_ERROR;
+	}
+	Byte decoder_props[LZMA_PROPS_SIZE];
+	SizeT props_size = sizeof(decoder_props);
+	if (LzmaEnc_WriteProperties(encoder, decoder_props, &props_size) != SZ_OK)
+	{
+		LzmaEnc_Destroy(encoder, &m_allocator, &m_allocator);
+		throw CHDERR_DECOMPRESSION_ERROR;
+	}
+	LzmaEnc_Destroy(encoder, &m_allocator, &m_allocator);
 
 	// do memory allocations
-	SRes res = LzmaDec_Allocate_MAME(&m_decoder, &decoder_props, &m_allocator);
+	SRes res = LzmaDec_Allocate(&m_decoder, decoder_props, LZMA_PROPS_SIZE, &m_allocator);
 	if (res != SZ_OK)
 		throw CHDERR_DECOMPRESSION_ERROR;
 }

--- a/archivers/chd/chdtypes.h
+++ b/archivers/chd/chdtypes.h
@@ -31,6 +31,10 @@
 #define CLIB_DECL __cdecl
 #define FLAC_API_EXPORTS
 
+#if defined(CPU_64_BIT) && !defined(PTR64)
+#define PTR64 1
+#endif
+
 /* Macros for normalizing data into big or little endian formats */
 #define FLIPENDIAN_INT16(x)	(((((UINT16) (x)) >> 8) | ((x) << 8)) & 0xffff)
 #define FLIPENDIAN_INT32(x)	((((UINT32) (x)) << 24) | (((UINT32) (x)) >> 24) | \

--- a/archivers/chd/osdcomm.h
+++ b/archivers/chd/osdcomm.h
@@ -36,7 +36,7 @@
 #define ATTR_MALLOC             __attribute__((malloc))
 #define ATTR_PURE               __attribute__((pure))
 #define ATTR_CONST              __attribute__((const))
-#define ATTR_FORCE_INLINE       __attribute__((always_inline))
+#define ATTR_FORCE_INLINE       inline __attribute__((always_inline))
 #define ATTR_NONNULL(...)       __attribute__((nonnull(__VA_ARGS__)))
 #define ATTR_DEPRECATED         __attribute__((deprecated))
 /* not supported in GCC prior to 4.4.x */

--- a/cd32_fmv.cpp
+++ b/cd32_fmv.cpp
@@ -25,8 +25,14 @@
 #include "archivers/mp2/kjmp2.h"
 
 #ifdef WITH_LIBMPEG2
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "mpeg2.h"
 #include "mpeg2convert.h"
+#ifdef __cplusplus
+}
+#endif
 #endif
 
 #define FMV_DEBUG 0

--- a/include/zarchive.h
+++ b/include/zarchive.h
@@ -123,7 +123,6 @@ extern struct zvolume *archive_directory_lha(struct zfile *zf);
 extern struct zfile *archive_access_lha (struct znode *zn);
 extern struct zvolume *archive_directory_zip(struct zfile *zf);
 extern struct zvolume *archive_directory_7z (struct zfile *z);
-extern struct zfile *archive_access_7z (struct znode *zn);
 extern struct zvolume *archive_directory_rar (struct zfile *z);
 extern struct zfile *archive_access_rar (struct znode *zn);
 extern struct zvolume *archive_directory_lzx (struct zfile *in_file);

--- a/prowizard/include/extern.h
+++ b/prowizard/include/extern.h
@@ -354,7 +354,12 @@ extern char Extensions[_KNOWN_FORMATS+1][33];
 extern Uchar CONVERT;
 extern Uchar Amiga_EXE_Header;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void pw_write_log (const char *, ...);
 extern FILE *moduleripper2_fopen (const char *name, const char *mode, const char *aid, int addr, int size);
 extern FILE *moduleripper_fopen (const char *aname, const char *amode);
-
+#ifdef __cplusplus
+}
+#endif

--- a/prowizard/prowiz.c
+++ b/prowizard/prowiz.c
@@ -13,6 +13,9 @@
 #if 0
 int main ( int ac , char **av )
 #else
+#ifdef __cplusplus
+extern "C"
+#endif
 int prowizard_search (Uchar *in_data_p, int PW_in_size_p)
 #endif
 {

--- a/zfile.cpp
+++ b/zfile.cpp
@@ -1160,7 +1160,10 @@ static struct zfile *wrp (struct zfile *z, int *retcode)
 
 #ifdef A_7Z
 #include "7z/Xz.h"
-#include "7z/Lzmadec.h"
+#include "7z/LzmaDec.h"
+#ifdef UAE_7Z_SDK_1604
+#define LZMA_FINISH_ANY CODER_FINISH_ANY
+#endif
 #include "7z/7zCrc.h"
 
 static void *SzAlloc (void *p, size_t size)

--- a/zfile_archive.cpp
+++ b/zfile_archive.cpp
@@ -510,6 +510,7 @@ static struct zfile *archive_unpack_zip (struct zfile *zf)
 
 #include "7z/7z.h"
 #include "7z/Alloc.h"
+#include "7z/7zBuf.h"
 #include "7z/7zFile.h"
 #include "7z/7zVersion.h"
 #include "7z/7zCrc.h"
@@ -573,6 +574,51 @@ static void init_7z (void)
 	_tzset ();
 }
 
+#ifdef UAE_7Z_SDK_1604
+static TCHAR *sevenzip_get_name(const CSzArEx *db, UInt32 index)
+{
+	size_t len = SzArEx_GetFileNameUtf16(db, index, NULL);
+	UInt16 *src = xcalloc(UInt16, len > 0 ? len : 1);
+	TCHAR *out;
+
+	SzArEx_GetFileNameUtf16(db, index, src);
+#if defined(UNICODE) || defined(_UNICODE)
+	out = xmalloc(TCHAR, len > 0 ? len : 1);
+	for (size_t i = 0; i < len; i++)
+		out[i] = (TCHAR)src[i];
+	if (!len)
+		out[0] = 0;
+#else
+	out = xmalloc(TCHAR, len * 4 + 1);
+	size_t o = 0;
+	for (size_t i = 0; i < len && src[i]; i++) {
+		uae_u32 c = src[i];
+		if (c >= 0xd800 && c <= 0xdbff && i + 1 < len && src[i + 1] >= 0xdc00 && src[i + 1] <= 0xdfff) {
+			c = 0x10000 + ((c - 0xd800) << 10) + (src[++i] - 0xdc00);
+		}
+		if (c < 0x80) {
+			out[o++] = (TCHAR)c;
+		} else if (c < 0x800) {
+			out[o++] = (TCHAR)(0xc0 | (c >> 6));
+			out[o++] = (TCHAR)(0x80 | (c & 0x3f));
+		} else if (c < 0x10000) {
+			out[o++] = (TCHAR)(0xe0 | (c >> 12));
+			out[o++] = (TCHAR)(0x80 | ((c >> 6) & 0x3f));
+			out[o++] = (TCHAR)(0x80 | (c & 0x3f));
+		} else {
+			out[o++] = (TCHAR)(0xf0 | (c >> 18));
+			out[o++] = (TCHAR)(0x80 | ((c >> 12) & 0x3f));
+			out[o++] = (TCHAR)(0x80 | ((c >> 6) & 0x3f));
+			out[o++] = (TCHAR)(0x80 | (c & 0x3f));
+		}
+	}
+	out[o] = 0;
+#endif
+	xfree(src);
+	return out;
+}
+#endif
+
 struct SevenZContext
 {
 	CSzArEx db;
@@ -623,6 +669,33 @@ struct zvolume *archive_directory_7z (struct zfile *z)
 		return NULL;
 	}
 	zv = zvolume_alloc (z, ArchiveFormat7Zip, ctx, NULL);
+#ifdef UAE_7Z_SDK_1604
+	for (i = 0; i < ctx->db.NumFiles; i++) {
+		TCHAR *name = sevenzip_get_name(&ctx->db, i);
+		struct zarchive_info zai;
+
+		memset(&zai, 0, sizeof zai);
+		zai.name = name;
+		zai.flags = SzBitWithVals_Check(&ctx->db.Attribs, i) ? ctx->db.Attribs.Vals[i] : -1;
+		zai.size = SzArEx_GetFileSize(&ctx->db, i);
+		if (SzBitWithVals_Check(&ctx->db.MTime, i)) {
+			CNtfsFileTime *mt = ctx->db.MTime.Vals + i;
+			uae_u64 t = (((uae_u64)mt->High) << 32) | mt->Low;
+			if (t >= EPOCH_DIFF) {
+				zai.tv.tv_sec = (t - EPOCH_DIFF) / RATE_DIFF;
+				zai.tv.tv_sec -= _timezone;
+				if (_daylight)
+					zai.tv.tv_sec += 1 * 60 * 60;
+			}
+		}
+		if (!SzArEx_IsDir(&ctx->db, i)) {
+			struct znode *zn = zvolume_addfile_abs (zv, &zai);
+			if (zn)
+				zn->offset = i;
+		}
+		xfree(name);
+	}
+#else
 	for (i = 0; i < ctx->db.db.NumFiles; i++) {
 		CSzFileItem *f = ctx->db.db.Files + i;
 		TCHAR *name = (TCHAR*)(ctx->db.FileNames.data + ctx->db.FileNameOffsets[i] * 2);
@@ -647,6 +720,7 @@ struct zvolume *archive_directory_7z (struct zfile *z)
 				zn->offset = i;
 		}
 	}
+#endif
 	zv->method = ArchiveFormat7Zip;
 	return zv;
 }


### PR DESCRIPTION
## Summary

Make the archive/media helpers build cleanly with portable external
dependencies and C++ linkage rules.

This keeps the existing archive code paths intact where possible while adding
compatibility for the official LZMA SDK 16.04 headers/APIs, libmpeg2 C headers,
and CHD helper headers on GCC/Clang builds.

## Details

  - Use the public LZMA property writer in the CHD LZMA path instead of relying
    on the MAME-only allocator helper.
  - Make `ATTR_FORCE_INLINE` provide `inline` on GCC/Clang so header-defined CHD
    helpers can be included by multiple translation units.
  - Define `PTR64` from `CPU_64_BIT` when the build has not already provided it.
  - Support the official LZMA SDK 16.04 API and header spelling.
  - Keep `archive_access_7z()` internal by removing the stale public prototype
    instead of widening the function linkage.
  - Add C++ linkage guards for ProWizard ripper hooks and libmpeg2 includes so C
    symbols are used when included from C++.
