### PR TITLE
sound: fix portable board audio helpers

### DIFF
--- a/cfgfile.cpp
+++ b/cfgfile.cpp
@@ -6298,7 +6298,12 @@ static int cfgfile_parse_hardware (struct uae_prefs *p, const TCHAR *option, TCH
 	if (cfgfile_yesno(option, value, _T("toccata_mixer"), &dummybool))
 	{
 		if (dummybool) {
+			int idx = 0;
 			addbcromtype(p, ROMTYPE_TOCCATA, true, NULL, 0);
+			struct boardromconfig *brc = get_device_rom(p, ROMTYPE_TOCCATA, 0, &idx);
+			if (brc) {
+				brc->roms[idx].device_settings |= 1;
+			}
 		}
 		return 1;
 	}

--- a/dsp3210/DSP3210_emulation.cpp
+++ b/dsp3210/DSP3210_emulation.cpp
@@ -37,7 +37,7 @@ float DSP_history_a[5][5];
 uint16_t DSP_history_CC[5];
 int32_t DSP_history_mem[5][5];
 uint8_t *DSP_onboard_RAM;
-uint8_t DSP_onboard_ROM[];
+extern uint8_t DSP_onboard_ROM[];
 uint8_t *DSP_MMIO;
 
 /* Defines */

--- a/dsp3210/dsp_glue.cpp
+++ b/dsp3210/dsp_glue.cpp
@@ -15,6 +15,7 @@
 #include "debug.h"
 #include "newcpu.h"
 #include "threaddep/thread.h"
+#include "machdep/maccess.h"
 #include "dsp_glue.h"
 
 #define DSP_INST_COUNT_WAIT 1000
@@ -56,7 +57,7 @@ uint32_t DSP_get_long_ext(uint32_t addr)
 	} else {
 		v = safe_memory_read(addr, 4);
 	}
-	v = _byteswap_ulong(v);
+	v = do_byteswap_32(v);
 	if (log_dsp) {
 		write_log("DSP LGET %08x = %08x\n", addr, v);
 	}
@@ -71,7 +72,7 @@ uint16_t DSP_get_short_ext(uint32_t addr)
 	} else {
 		v = safe_memory_read(addr, 2);
 	}
-	v = _byteswap_ushort(v);
+	v = do_byteswap_16(v);
 	if (log_dsp) {
 		write_log("DSP WGET %08x = %04x\n", addr, v & 0xffff);
 	}
@@ -94,7 +95,7 @@ unsigned char DSP_get_char_ext(uint32_t addr)
 
 void DSP_set_long_ext(uint32_t addr, uint32_t v)
 {
-	v = _byteswap_ulong(v);
+	v = do_byteswap_32(v);
 	if (log_dsp) {
 		write_log("DSP LPUT %08x = %08x\n", addr, v);
 	}
@@ -107,7 +108,7 @@ void DSP_set_long_ext(uint32_t addr, uint32_t v)
 
 void DSP_set_short_ext(uint32_t addr, uint16_t v)
 {
-	v = _byteswap_ushort(v);
+	v = do_byteswap_16(v);
 	if (log_dsp) {
 		write_log("DSP WPUT %08x = %04x\n", addr, v & 0xffff);
 	}

--- a/mame/a2410.cpp
+++ b/mame/a2410.cpp
@@ -70,8 +70,6 @@ struct a2410_struct
 
 static struct a2410_struct a2410_data;
 
-extern addrbank tms_bank;
-
 int mscreen::hpos()
 {
 	if (a2410_data.a2410_displayend) {

--- a/qemuvga/qemuaudio.h
+++ b/qemuvga/qemuaudio.h
@@ -32,6 +32,7 @@ struct SWVoiceOut
 	audfmt_e fmt;
 	int left_volume, right_volume;
 	int streamid;
+	struct SWVoiceOut *next;
 };
 struct SWVoiceIn
 {

--- a/sndboard.cpp
+++ b/sndboard.cpp
@@ -1679,7 +1679,12 @@ static void codec_start(struct snddev_data *data)
 	if (data->snddev_active & STATUS_FIFO_RECORD) {
 		data->capture_buffer_size = 48000 * 2 * 2; // 1s at 48000/stereo/16bit
 		data->capture_buffer = xcalloc(uae_u8, data->capture_buffer_size);
-		sndboard_init_capture(data->freq_adjusted);
+		if (!sndboard_init_capture(data->freq_adjusted)) {
+			write_log(_T("SNDDEV capture unavailable, recording disabled\n"));
+			data->snddev_active &= ~STATUS_FIFO_RECORD;
+			xfree(data->capture_buffer);
+			data->capture_buffer = NULL;
+		}
 	}
 }
 

--- a/sndboard.cpp
+++ b/sndboard.cpp
@@ -2831,7 +2831,7 @@ static SWVoiceOut *qemu_voice_out;
 
 static bool audio_state_sndboard_qemu(int streamid, void *params)
 {
-	SWVoiceOut *out = qemu_voice_out;
+	SWVoiceOut *out = (SWVoiceOut*)params;
 
 	if (!out || !out->active)
 		return false;
@@ -2876,13 +2876,28 @@ static bool audio_state_sndboard_qemu(int streamid, void *params)
 	return true;
 }
 
-static void calculate_volume_qemu(void)
+static void calculate_volume_qemu(SWVoiceOut *out)
 {
-	SWVoiceOut *out = qemu_voice_out;
 	if (!out)
 		return;
 	out->left_volume = (100 - currprefs.sound_volume_board) * 32768 / 100;
 	out->right_volume = (100 - currprefs.sound_volume_board) * 32768 / 100;
+}
+
+static void calculate_volume_qemu_all(void)
+{
+	for (SWVoiceOut *out = qemu_voice_out; out; out = out->next) {
+		calculate_volume_qemu(out);
+	}
+}
+
+static bool qemu_voice_out_active(void)
+{
+	for (SWVoiceOut *out = qemu_voice_out; out; out = out->next) {
+		if (out->active)
+			return true;
+	}
+	return false;
 }
 
 void AUD_close_in(QEMUSoundCard *card, SWVoiceIn *sw)
@@ -2890,25 +2905,31 @@ void AUD_close_in(QEMUSoundCard *card, SWVoiceIn *sw)
 }
 int AUD_read(SWVoiceIn *sw, void *pcm_buf, int size)
 {
-	return size;
+	return 0;
 }
 int AUD_write(SWVoiceOut *sw, void *pcm_buf, int size)
 {
+	if (!sw || !pcm_buf || size <= 0)
+		return 0;
+	if (size > (int)sizeof(sw->samplebuf))
+		size = sizeof(sw->samplebuf);
 	memcpy(sw->samplebuf, pcm_buf, size);
 	sw->samplebuf_total = size;
 	return sw->samplebuf_total;
 }
 void AUD_set_active_out(SWVoiceOut *sw, int on)
 {
+	if (!sw)
+		return;
 	sw->active = on != 0;
 	sw->event_time = (int)(base_event_clock * CYCLE_UNIT / sw->freq);
 	sw->samplebuf_index = 0;
 	sw->samplebuf_total = 0;
-	calculate_volume_qemu();
+	calculate_volume_qemu(sw);
 	audio_enable_stream(false, sw->streamid, 2, NULL, NULL);
 	sw->streamid = 0;
 	if (on) {
-		sw->streamid = audio_enable_stream(true, -1, 2, audio_state_sndboard_qemu, NULL);
+		sw->streamid = audio_enable_stream(true, -1, 2, audio_state_sndboard_qemu, sw);
 	}
 }
 void AUD_set_active_in(SWVoiceIn *sw, int on)
@@ -2920,8 +2941,15 @@ int  AUD_is_active_in(SWVoiceIn *sw)
 }
 void AUD_close_out(QEMUSoundCard *card, SWVoiceOut *sw)
 {
-	qemu_voice_out = NULL;
 	if (sw) {
+		SWVoiceOut **outp = &qemu_voice_out;
+		while (*outp) {
+			if (*outp == sw) {
+				*outp = sw->next;
+				break;
+			}
+			outp = &(*outp)->next;
+		}
 		audio_enable_stream(false, sw->streamid, 0, NULL, NULL);
 		sw->streamid = 0;
 		xfree(sw);
@@ -2946,8 +2974,11 @@ SWVoiceOut *AUD_open_out(
 	struct audsettings *settings)
 {
 	SWVoiceOut *out = sw;
-	if (!sw)
+	if (!sw) {
 		out = xcalloc(SWVoiceOut, 1);
+		out->next = qemu_voice_out;
+		qemu_voice_out = out;
+	}
 	int bits = 8;
 
 	if (settings->fmt >= AUD_FMT_U16)
@@ -2967,8 +2998,6 @@ SWVoiceOut *AUD_open_out(
 	write_log(_T("QEMU AUDIO: freq=%d ch=%d bits=%d (fmt=%d) '%s'\n"), out->freq, out->ch, bits, settings->fmt, name2);
 	xfree(name2);
 
-	qemu_voice_out = out;
-
 	return out;
 }
 
@@ -2983,7 +3012,7 @@ static void sndboard_vsync(void)
 		sndboard_vsync_toccata(&snddev[0]);
 	if (fm801_active)
 		sndboard_vsync_fm801();
-	if (qemu_voice_out && qemu_voice_out->active)
+	if (qemu_voice_out_active())
 		sndboard_vsync_qemu();
 }
 
@@ -2993,8 +3022,7 @@ void sndboard_ext_volume(void)
 		calculate_volume_toccata(&snddev[0]);
 	if (fm801_active)
 		calculate_volume_fm801();
-	if (qemu_voice_out && qemu_voice_out->active)
-		calculate_volume_qemu();
+	calculate_volume_qemu_all();
 }
 
 static void snd_init(void)


### PR DESCRIPTION
## Summary

Fix several small board and audio integration issues that affect portable
builds and QEMU-backed sound boards.

The main functional fix is in the QEMU audio shim: it now tracks each output
voice separately instead of replacing one global pointer, which matters for
devices such as ES1370 that can expose more than one DAC output.

## Details

  - Use portable byte-swap helpers and correct external ROM declarations in the
    DSP3210 glue.
  - Track QEMU output voices in a small list so each audio stream reads from its
    own buffer.
  - Pass the active output voice through the audio callback instead of using a
    single global voice.
  - Clamp QEMU audio writes to the local sample buffer size.
  - Report no input samples until the capture path has a real backend.
  - Disable sound-board recording if host capture setup fails.
  - Preserve the old `toccata_mixer` configuration behavior by mapping it to the
    current Toccata board setting.
  - Drop an unused A2410 `tms_bank` extern declaration.
