### PR TITLE
pcem: fix bridgeboard build integration

### DIFF
--- a/pcem/386_dynarec.cpp
+++ b/pcem/386_dynarec.cpp
@@ -10,7 +10,9 @@
 #include "x87.h"
 #include "mem.h"
 #include "codegen.h"
+#ifndef UAE
 #include "codegen_backend.h"
+#endif
 #include "cpu.h"
 #include "fdc.h"
 #include "nmi.h"
@@ -237,12 +239,12 @@ static void prefetch_flush()
 
 #include "386_ops.h"
 
+int cpu_end_block_after_ins = 0;
+
+#ifndef UAE
 
 #define CACHE_ON() (!(cr0 & (1 << 30)) && !(cpu_state.flags & T_FLAG))
 //#define CACHE_ON() 0
-
-int cpu_end_block_after_ins = 0;
-
 
 static inline void exec_interpreter(void)
 {
@@ -660,3 +662,5 @@ void exec386_dynarec(int cycs)
                 cycles_main -= (cycles_start - cycles);
         }
 }
+
+#endif

--- a/pcem/cpu.h
+++ b/pcem/cpu.h
@@ -104,6 +104,7 @@ typedef struct
 
 extern CPU *cpu_s;
 
+#if 0
 extern CPU cpus_8088[];
 extern CPU cpus_8086[];
 extern CPU cpus_286[];
@@ -138,6 +139,7 @@ extern CPU cpus_ibmxt286[];
 extern CPU cpus_ps1_m2011[];
 extern CPU cpus_ps2_m30_286[];
 extern CPU cpus_acer[];
+#endif
 
 extern int cpu_iscyrix;
 extern int cpu_16bitbus;

--- a/pcem/keyboard_at.h
+++ b/pcem/keyboard_at.h
@@ -5,6 +5,5 @@ void keyboard_at_poll();
 void keyboard_at_set_mouse(void (*mouse_write)(uint8_t val, void *p), void *p);
 void keyboard_at_adddata_mouse(uint8_t val);
 
-extern uint8_t mouse_queue[16];
 extern int mouse_queue_start, mouse_queue_end;
 extern int mouse_scan;

--- a/pcem/model.h
+++ b/pcem/model.h
@@ -44,7 +44,9 @@ int model_getmodel(int romset);
 char *model_getname();
 char *model_get_internal_name();
 int model_get_model_from_internal_name(char *s);
+#if 0
 void model_init();
+#endif
 device_t *model_getdevice(int model);
 int model_has_fixed_gfx(int model);
 int model_has_optional_gfx(int model);

--- a/pcem/pcemglue.cpp
+++ b/pcem/pcemglue.cpp
@@ -359,7 +359,8 @@ void midi_write(uint8_t v)
 	if (!midi_open) {
 		midi_open = Midi_Open();
 	}
-	Midi_Parse(midi_output, &v);
+	BYTE b = (BYTE)v;
+	Midi_Parse(midi_output, &b);
 #endif
 }
 

--- a/pcem/pcemglue.cpp
+++ b/pcem/pcemglue.cpp
@@ -821,15 +821,28 @@ void thread_sleep(int n)
 	sleep_millis(n);
 }
 
-thread_t *thread_create(void (*thread_rout)(void *param), void *param)
+typedef struct pcem_thread_handle
 {
 	uae_thread_id tid;
-	uae_start_thread(_T("PCem helper"), thread_rout, param, &tid);
-	return tid;
+} pcem_thread_handle;
+
+thread_t *thread_create(void (*thread_rout)(void *param), void *param)
+{
+	pcem_thread_handle *handle = xcalloc(pcem_thread_handle, 1);
+	if (!uae_start_thread(_T("PCem helper"), thread_rout, param, &handle->tid)) {
+		xfree(handle);
+		return NULL;
+	}
+	return (thread_t*)handle;
 }
 void thread_kill(thread_t *handle)
 {
-	uae_end_thread((uae_thread_id*)&handle);
+	if (!handle) {
+		return;
+	}
+	pcem_thread_handle *thread = (pcem_thread_handle*)handle;
+	uae_end_thread(&thread->tid);
+	xfree(thread);
 }
 event_t *thread_create_event(void)
 {
@@ -842,25 +855,30 @@ int thread_wait(thread_t *arg)
 	if (!arg) {
 		return 0;
 	}
-	uae_sem_wait((uae_sem_t*)&arg);
+	pcem_thread_handle *thread = (pcem_thread_handle*)arg;
+	uae_wait_thread(thread->tid);
+	xfree(thread);
 	return 1;
 }
 void thread_set_event(event_t *event)
 {
-	uae_sem_post((uae_sem_t*)&event);
+	uae_sem_t sem = (uae_sem_t)event;
+	uae_sem_post(&sem);
 }
 void thread_reset_event(event_t *_event)
 {
-	uae_sem_init((uae_sem_t*)&_event, 1, 0);
+	uae_sem_t sem = (uae_sem_t)_event;
+	uae_sem_unpost(&sem);
 }
 int thread_wait_event(event_t *event, int timeout)
 {
-	uae_sem_trywait_delay((uae_sem_t*)&event, timeout < 0 ? INFINITE : timeout);
-	return 0;
+	uae_sem_t sem = (uae_sem_t)event;
+	return uae_sem_trywait_delay(&sem, timeout < 0 ? -1 : timeout);
 }
 void thread_destroy_event(event_t *_event)
 {
-	uae_sem_destroy((uae_sem_t*)&_event);
+	uae_sem_t sem = (uae_sem_t)_event;
+	uae_sem_destroy(&sem);
 }
 
 typedef struct win_mutex_t

--- a/pcem/pcemglue.h
+++ b/pcem/pcemglue.h
@@ -10,8 +10,6 @@ uint32_t mem_read_romextl(uint32_t addr, void *priv);
 void pcem_linear_mark(int offset);
 
 extern int SOUNDBUFLEN;
-extern int32_t *x86_sndbuffer[2];
-extern bool x86_sndbuffer_filled[2];
 
 extern void *pcem_mapping_linear_priv;
 extern uae_u32 pcem_mapping_linear_offset;

--- a/pcem/vid_bt482_ramdac.cpp
+++ b/pcem/vid_bt482_ramdac.cpp
@@ -2,6 +2,7 @@
 /* BT482 RAMDAC (based on 86box BT484) */
 
 #include <memory>
+#include <cstdlib>
 #include "ibm.h"
 #include "mem.h"
 #include "device.h"

--- a/pcem/vid_mga.cpp
+++ b/pcem/vid_mga.cpp
@@ -47,7 +47,7 @@ extern void activate_debugger(void);
 
 #define FIFO_SIZE        65536
 #define FIFO_MASK        (FIFO_SIZE - 1)
-#define FIFO_ENTRY_SIZE  (1 << 31)
+#define FIFO_ENTRY_SIZE  (UINT32_C(1) << 31)
 #define FIFO_THRESHOLD   0xe000
 
 #define WAKE_DELAY       (100 * TIMER_USEC) /* 100us */
@@ -337,7 +337,7 @@ extern void activate_debugger(void);
 #define MACCESS_FOGEN                 (1 << 26)
 #define MACCESS_TLUTLOAD              (1 << 29)
 #define MACCESS_NODITHER              (1 << 30)
-#define MACCESS_DIT555                (1 << 31)
+#define MACCESS_DIT555                (UINT32_C(1) << 31)
 
 #define PITCH_MASK                    0xfe0
 #define PITCH_YLIN                    (1 << 15)
@@ -386,7 +386,7 @@ extern void activate_debugger(void);
 #define TEXCTL_CLAMPU                 (1 << 28)
 #define TEXCTL_TMODULATE              (1 << 29)
 #define TEXCTL_STRANS                 (1 << 30)
-#define TEXCTL_ITRANS                 (1 << 31)
+#define TEXCTL_ITRANS                 (UINT32_C(1) << 31)
 
 #define TEXHEIGHT_TH_MASK             (0x3f << 0)
 #define TEXHEIGHT_THMASK_SHIFT        (18)
@@ -407,7 +407,7 @@ extern void activate_debugger(void);
 
 /*PCI configuration registers*/
 #define OPTION_INTERLEAVE (1 << 12)
-#define OPTION_POWERPC (1 << 31)
+#define OPTION_POWERPC (UINT32_C(1) << 31)
 
 enum {
     MGA_2064W,  /*Millennium*/
@@ -3922,7 +3922,7 @@ blit_iload_iload(mystique_t *mystique, uint32_t data, int size)
 
                 case DWGCTRL_BLTMOD_BMONOWF:
                     data      = (data >> 24) | ((data & 0x00ff0000) >> 8) | ((data & 0x0000ff00) << 8) | (data << 24);
-                    data_mask = (1 << 31);
+                    data_mask = (UINT32_C(1) << 31);
                 case DWGCTRL_BLTMOD_BMONOLEF:
                     while (size) {
                         if (mystique->dwgreg.xdst >= mystique->dwgreg.cxleft && mystique->dwgreg.xdst <= mystique->dwgreg.cxright && mystique->dwgreg.ydst_lin >= mystique->dwgreg.ytop && mystique->dwgreg.ydst_lin <= mystique->dwgreg.ybot && ((data & data_mask) || !(mystique->dwgreg.dwgctrl_running & DWGCTRL_TRANSC)) && trans[mystique->dwgreg.xdst & 3]) {

--- a/pcem/vid_mga.cpp
+++ b/pcem/vid_mga.cpp
@@ -20,7 +20,14 @@
 #include <string.h>
 #include <stdlib.h>
 #include <wchar.h>
+#ifdef __cplusplus
+#include <atomic>
+using std::atomic_bool;
+using std::atomic_int;
+using std::atomic_uint;
+#else
 #include <stdatomic.h>
+#endif
 #include "ibm.h"
 #include "device.h"
 #include "io.h"

--- a/pcem/vid_voodoo.cpp
+++ b/pcem/vid_voodoo.cpp
@@ -1085,7 +1085,7 @@ void *voodoo_card_init()
                 ai88[c].b = c & 0xff;
         }
 #ifndef NO_CODEGEN
-#if (defined WIN32 || defined WIN64) && !defined(ARM64)
+#ifdef PCEM_VOODOO_CODEGEN
         voodoo_codegen_init(voodoo);
 #endif
 #endif
@@ -1205,7 +1205,7 @@ void *voodoo_2d3d_card_init(int type)
                 ai88[c].b = c & 0xff;
         }
 #ifndef NO_CODEGEN
-#if (defined WIN32 || defined WIN64) && !defined(ARM64)
+#ifdef PCEM_VOODOO_CODEGEN
         voodoo_codegen_init(voodoo);
 #endif
 #endif
@@ -1322,7 +1322,7 @@ void voodoo_card_close(voodoo_t *voodoo)
                 free(voodoo->texture_cache[0][c].data);
         }
 #ifndef NO_CODEGEN
-#if (defined WIN32 || defined WIN64) && !defined(ARM64)
+#ifdef PCEM_VOODOO_CODEGEN
         voodoo_codegen_close(voodoo);
 #endif
 #endif

--- a/pcem/vid_voodoo_codegen_x86-64.h
+++ b/pcem/vid_voodoo_codegen_x86-64.h
@@ -73,6 +73,14 @@ static int next_block_to_write[4] = {0, 0};
                         fatal("Over!\n");                       \
         } while (0)
 
+#define VOODOO_OFFSETOF_ARRAY(type, field, index)               \
+        (offsetof(type, field[0]) +                             \
+        ((index) * sizeof(((type *)0)->field[0])))
+
+#define VOODOO_OFFSETOF_ARRAY_MEMBER(type, field, index, member) \
+        (offsetof(type, field[0].member) +                      \
+        ((index) * sizeof(((type *)0)->field[0])))
+
 
 static __m128i xmm_01_w;// = 0x0001000100010001ull;
 static __m128i xmm_ff_w;// = 0x00ff00ff00ff00ffull;
@@ -173,21 +181,21 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                 addbyte(0xd0);
                 addbyte(0x03); /*ADD EAX, state->lod*/
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, tmu[tmu].lod));
+                addlong(VOODOO_OFFSETOF_ARRAY_MEMBER(voodoo_state_t, tmu, tmu, lod));
                 addbyte(0x3b); /*CMP EAX, state->lod_min*/
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
                 addbyte(0x0f); /*CMOVL EAX, state->lod_min*/
                 addbyte(0x4c);
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
                 addbyte(0x3b); /*CMP EAX, state->lod_max*/
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_max[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_max, tmu));
                 addbyte(0x0f); /*CMOVNL EAX, state->lod_max*/
                 addbyte(0x4d);
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_max[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_max, tmu));
                 addbyte(0xc1); /*SHR EAX, 8*/
                 addbyte(0xe8);
                 addbyte(8);        
@@ -211,7 +219,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                 addbyte(28);
                 addbyte(0x8b); /*MOV EBX, state->lod_min*/
                 addbyte(0x9f);
-                addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
                 addbyte(0x48); /*SHR RCX, 28*/
                 addbyte(0xc1);
                 addbyte(0xe9);
@@ -326,7 +334,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         addbyte(0x8b);
                         addbyte(0xac);
                         addbyte(0xcf);
-                        addlong(offsetof(voodoo_state_t, tex[tmu]));
+                        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex, tmu));
                         addbyte(0x88); /*MOV CL, DL*/
                         addbyte(0xd1);
                         addbyte(0x89); /*MOV EDX, EBX*/
@@ -335,7 +343,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         {
                                 addbyte(0x23); /*AND EAX, params->tex_w_mask[ESI]*/
                                 addbyte(0x86);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                         }
                         addbyte(0x83); /*ADD EDX, 1*/
                         addbyte(0xc2);
@@ -348,11 +356,11 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addbyte(0x12);
                                 addbyte(0x3b); /*CMP EDX, params->tex_h_mask[ESI]*/
                                 addbyte(0x96);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                                 addbyte(0x0f); /*CMOVA EDX, params->tex_h_mask[ESI]*/
                                 addbyte(0x47);
                                 addbyte(0x96);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                                 addbyte(0x85); /*TEST EBX,EBX*/
                                 addbyte(0xdb);
                                 addbyte(0x41); /*CMOVS EBX, R10(alookup[0](zero))*/
@@ -361,20 +369,20 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addbyte(0x1a);
                                 addbyte(0x3b); /*CMP EBX, params->tex_h_mask[ESI]*/
                                 addbyte(0x9e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                                 addbyte(0x0f); /*CMOVA EBX, params->tex_h_mask[ESI]*/
                                 addbyte(0x47);
                                 addbyte(0x9e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                         }
                         else
                         {
                                 addbyte(0x23); /*AND EDX, params->tex_h_mask[ESI]*/
                                 addbyte(0x96);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                                 addbyte(0x23); /*AND EBX, params->tex_h_mask[ESI]*/
                                 addbyte(0x9e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                         }
                         /*EAX = S, EBX = T0, EDX = T1*/
                         addbyte(0xd3); /*SHL EBX, CL*/
@@ -395,7 +403,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         {
                                 addbyte(0x8b); /*MOV EBP, params->tex_w_mask[ESI]*/
                                 addbyte(0xae);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                                 addbyte(0x85); /*TEST EAX, EAX*/
                                 addbyte(0xc0);
                                 addbyte(0x8b); /*MOV ebp_store2, RSI*/
@@ -419,7 +427,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         {
                                 addbyte(0x3b); /*CMP EAX, params->tex_w_mask[ESI] - is S at texture edge (ie will wrap/clamp)?*/
                                 addbyte(0x86);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                                 addbyte(0x8b); /*MOV ebp_store2, ESI*/
                                 addbyte(0xb7);
                                 addlong(offsetof(voodoo_state_t, ebp_store));
@@ -576,7 +584,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         addbyte(0x8b);
                         addbyte(0xac);
                         addbyte(0xcf);
-                        addlong(offsetof(voodoo_state_t, tex[tmu]));
+                        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex, tmu));
                         addbyte(0x28); /*SUB DL, CL*/
                         addbyte(0xca);
                         addbyte(0x80); /*ADD CL, 4*/
@@ -622,12 +630,12 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addbyte(0x3b); /*CMP EAX, params->tex_w_mask[ESI+ECX*4]*/
                                 addbyte(0x84);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
                                 addbyte(0x0f); /*CMOVAE EAX, params->tex_w_mask[ESI+ECX*4]*/
                                 addbyte(0x43);
                                 addbyte(0x84);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
 
                         }
                         else
@@ -635,7 +643,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addbyte(0x23); /*AND EAX, params->tex_w_mask-0x10[ESI+ECX*4]*/
                                 addbyte(0x84);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
                         }
                         if (state->clamp_t[tmu])
                         {
@@ -648,19 +656,19 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addbyte(0x3b); /*CMP EBX, params->tex_h_mask[ESI+ECX*4]*/
                                 addbyte(0x9c);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
                                 addbyte(0x0f); /*CMOVAE EBX, params->tex_h_mask[ESI+ECX*4]*/
                                 addbyte(0x43);
                                 addbyte(0x9c);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
                         }
                         else
                         {
                                 addbyte(0x23); /*AND EBX, params->tex_h_mask-0x10[ESI+ECX*4]*/
                                 addbyte(0x9c);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
                         }
                         addbyte(0x88); /*MOV CL, DL*/
                         addbyte(0xd1);
@@ -3464,4 +3472,3 @@ void voodoo_codegen_close(voodoo_t *voodoo)
         munmap(voodoo->codegen_data, sizeof(voodoo_x86_data_t) * BLOCK_NUM*4);
 #endif
 }
-

--- a/pcem/vid_voodoo_codegen_x86.h
+++ b/pcem/vid_voodoo_codegen_x86.h
@@ -71,6 +71,14 @@ static int next_block_to_write[4] = {0, 0};
                         fatal("Over!\n");                       \
         } while (0)
 
+#define VOODOO_OFFSETOF_ARRAY(type, field, index)               \
+        (offsetof(type, field[0]) +                             \
+        ((index) * sizeof(((type *)0)->field[0])))
+
+#define VOODOO_OFFSETOF_ARRAY_MEMBER(type, field, index, member) \
+        (offsetof(type, field[0].member) +                      \
+        ((index) * sizeof(((type *)0)->field[0])))
+
 
 static __m128i xmm_01_w;// = 0x0001000100010001ull;
 static __m128i xmm_ff_w;// = 0x00ff00ff00ff00ffull;
@@ -143,21 +151,21 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                 addbyte(0xd8);
                 addbyte(0x03); /*ADD EAX, state->lod*/
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, tmu[tmu].lod));
+                addlong(VOODOO_OFFSETOF_ARRAY_MEMBER(voodoo_state_t, tmu, tmu, lod));
                 addbyte(0x3b); /*CMP EAX, state->lod_min*/
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
                 addbyte(0x0f); /*CMOVL EAX, state->lod_min*/
                 addbyte(0x4c);
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
                 addbyte(0x3b); /*CMP EAX, state->lod_max*/
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_max[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_max, tmu));
                 addbyte(0x0f); /*CMOVNL EAX, state->lod_max*/
                 addbyte(0x4d);
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_max[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_max, tmu));
                 addbyte(0x0f); /*MOVZX EBX, AL*/
                 addbyte(0xb6);
                 addbyte(0xd8);
@@ -166,7 +174,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                 addbyte(8);
                 addbyte(0x89); /*MOV state->lod_frac[tmu], EBX*/
                 addbyte(0x9f);
-                addlong(offsetof(voodoo_state_t, lod_frac[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_frac, tmu));
                 addbyte(0x89); /*MOV state->lod, EAX*/
                 addbyte(0x87);
                 addlong(offsetof(voodoo_state_t, lod));
@@ -185,11 +193,11 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                 addlong(tmu ? offsetof(voodoo_state_t, tmu1_t) : offsetof(voodoo_state_t, tmu0_t));
                 addbyte(0xc7); /*MOV state->lod[tmu], 0*/
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_frac[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_frac, tmu));
                 addlong(0);
                 addbyte(0x8b); /*MOV EAX, state->lod_min*/
                 addbyte(0x87);
-                addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
                 addbyte(0x66); /*SHRQ XMM4, 28*/
                 addbyte(0x0f);
                 addbyte(0x73);
@@ -218,7 +226,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                 addlong(offsetof(voodoo_state_t, tex_t));
                 addbyte(0x89); /*MOV state->lod_frac[tmu], EBX*/
                 addbyte(0x9f);
-                addlong(offsetof(voodoo_state_t, lod_frac[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_frac, tmu));
                 addbyte(0x89); /*MOV state->lod, EAX*/
                 addbyte(0x87);
                 addlong(offsetof(voodoo_state_t, lod));
@@ -230,7 +238,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                 {
                         addbyte(0x8b); /*MOV ECX, state->tex_lod[tmu]*/
                         addbyte(0x8f);
-                        addlong(offsetof(voodoo_state_t, tex_lod[tmu]));
+                        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex_lod, tmu));
                         addbyte(0xb2); /*MOV DL, 8*/
                         addbyte(8);
                         addbyte(0x8b); /*MOV ECX, [ECX+EAX*4]*/
@@ -312,7 +320,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         addbyte(0x8b); /*MOV EBP, state->tex[EDI+ECX*4]*/
                         addbyte(0xac);
                         addbyte(0x8f);
-                        addlong(offsetof(voodoo_state_t, tex[tmu]));
+                        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex, tmu));
                         addbyte(0x88); /*MOV CL, DL*/
                         addbyte(0xd1);
                         addbyte(0x89); /*MOV EDX, EBX*/
@@ -321,7 +329,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         {
                                 addbyte(0x23); /*AND EAX, params->tex_w_mask[ESI]*/
                                 addbyte(0x86);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                         }
                         addbyte(0x83); /*ADD EDX, 1*/
                         addbyte(0xc2);
@@ -334,11 +342,11 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addlong((uint32_t)&zero);
                                 addbyte(0x3b); /*CMP EDX, params->tex_h_mask[ESI]*/
                                 addbyte(0x96);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                                 addbyte(0x0f); /*CMOVA EDX, params->tex_h_mask[ESI]*/
                                 addbyte(0x47);
                                 addbyte(0x96);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                                 addbyte(0x85); /*TEST EBX,EBX*/
                                 addbyte(0xdb);
                                 addbyte(0x0f); /*CMOVS EBX, zero*/
@@ -347,20 +355,20 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addlong((uint32_t)&zero);
                                 addbyte(0x3b); /*CMP EBX, params->tex_h_mask[ESI]*/
                                 addbyte(0x9e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                                 addbyte(0x0f); /*CMOVA EBX, params->tex_h_mask[ESI]*/
                                 addbyte(0x47);
                                 addbyte(0x9e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                         }
                         else
                         {
                                 addbyte(0x23); /*AND EDX, params->tex_h_mask[ESI]*/
                                 addbyte(0x96);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                                 addbyte(0x23); /*AND EBX, params->tex_h_mask[ESI]*/
                                 addbyte(0x9e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                         }
                         /*EAX = S, EBX = T0, EDX = T1*/
                         addbyte(0xd3); /*SHL EBX, CL*/
@@ -379,7 +387,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         {
                                 addbyte(0x8b); /*MOV EBP, params->tex_w_mask[ESI]*/
                                 addbyte(0xae);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                                 addbyte(0x85); /*TEST EAX, EAX*/
                                 addbyte(0xc0);
                                 addbyte(0x8b); /*MOV ESI, ebp_store*/
@@ -403,7 +411,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         {
                                 addbyte(0x3b); /*CMP EAX, params->tex_w_mask[ESI] - is S at texture edge (ie will wrap/clamp)?*/
                                 addbyte(0x86);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                                 addbyte(0x8b); /*MOV ESI, ebp_store*/
                                 addbyte(0xb7);
                                 addlong(offsetof(voodoo_state_t, ebp_store));
@@ -550,7 +558,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                 {
                         addbyte(0x8b); /*MOV ECX, state->tex_lod[tmu]*/
                         addbyte(0x8f);
-                        addlong(offsetof(voodoo_state_t, tex_lod[tmu]));
+                        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex_lod, tmu));
                         addbyte(0xb2); /*MOV DL, 8*/
                         addbyte(8);
                         addbyte(0x8b); /*MOV ECX, [ECX+EAX*4]*/
@@ -559,7 +567,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                         addbyte(0x8b); /*MOV EBP, state->tex[EDI+ECX*4]*/
                         addbyte(0xac);
                         addbyte(0x8f);
-                        addlong(offsetof(voodoo_state_t, tex[tmu]));
+                        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex, tmu));
                         addbyte(0x28); /*SUB DL, CL*/
                         addbyte(0xca);
                         addbyte(0x80); /*ADD CL, 4*/
@@ -605,12 +613,12 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addbyte(0x3b); /*CMP EAX, params->tex_w_mask[ESI+ECX*4]*/
                                 addbyte(0x84);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
                                 addbyte(0x0f); /*CMOVAE EAX, params->tex_w_mask[ESI+ECX*4]*/
                                 addbyte(0x43);
                                 addbyte(0x84);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
 
                         }
                         else
@@ -618,7 +626,7 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addbyte(0x23); /*AND EAX, params->tex_w_mask-0x10[ESI+ECX*4]*/
                                 addbyte(0x84);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
                         }
                         if (state->clamp_t[tmu])
                         {
@@ -631,19 +639,19 @@ static inline int codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, v
                                 addbyte(0x3b); /*CMP EBX, params->tex_h_mask[ESI+ECX*4]*/
                                 addbyte(0x9c);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
                                 addbyte(0x0f); /*CMOVAE EBX, params->tex_h_mask[ESI+ECX*4]*/
                                 addbyte(0x43);
                                 addbyte(0x9c);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
                         }
                         else
                         {
                                 addbyte(0x23); /*AND EBX, params->tex_h_mask-0x10[ESI+ECX*4]*/
                                 addbyte(0x9c);
                                 addbyte(0x8e);
-                                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
                         }
                         addbyte(0x88); /*MOV CL, DL*/
                         addbyte(0xd1);

--- a/pcem/vid_voodoo_render.cpp
+++ b/pcem/vid_voodoo_render.cpp
@@ -646,9 +646,9 @@ static inline void voodoo_tmu_fetch_and_blend(voodoo_t *voodoo, voodoo_params_t 
                 state->tex_a[0] ^= 0xff;
 }
 
-#if (defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32) && !defined __amd64__ && !defined ARM64
+#if defined(PCEM_VOODOO_CODEGEN_X86)
 #include "vid_voodoo_codegen_x86.h"
-#elif (defined __amd64__ && defined WIN64 && !defined ARM64)
+#elif defined(PCEM_VOODOO_CODEGEN_X86_64)
 #include "vid_voodoo_codegen_x86-64.h"
 #else
 int voodoo_recomp = 0;
@@ -778,7 +778,7 @@ static void voodoo_half_triangle(voodoo_t *voodoo, voodoo_params_t *params, vood
         }
 #ifndef NO_CODEGEN
         typedef uint8_t(__cdecl *VOODOO_DRAW)(voodoo_state_t*,voodoo_params_t*, int,int);
-#if (defined WIN32 || defined WIN64) && !defined ARM64
+#ifdef PCEM_VOODOO_CODEGEN
         if (voodoo->use_recompiler)
                 voodoo_draw = (VOODOO_DRAW)voodoo_get_block(voodoo, params, state, odd_even);
         else

--- a/pcem/vid_voodoo_render.h
+++ b/pcem/vid_voodoo_render.h
@@ -1,4 +1,16 @@
-#if !(defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32) && !(defined __amd64__)
+#if !defined(ARM64) && !defined(_M_ARM64) && !defined(__aarch64__)
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || defined(WIN64)
+#define PCEM_VOODOO_CODEGEN_X86_64 1
+#elif defined(i386) || defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(_X86_)
+#define PCEM_VOODOO_CODEGEN_X86 1
+#endif
+#endif
+
+#if defined(PCEM_VOODOO_CODEGEN_X86) || defined(PCEM_VOODOO_CODEGEN_X86_64)
+#ifndef PCEM_VOODOO_CODEGEN
+#define PCEM_VOODOO_CODEGEN 1
+#endif
+#else
 #define NO_CODEGEN
 #endif
 

--- a/pci.cpp
+++ b/pci.cpp
@@ -45,7 +45,9 @@ static struct pci_bridge *bridges[PCI_BRIDGE_MAX + 1];
 static int last_bridge_index;
 static struct pci_board_state *hsyncs[MAX_PCI_BOARDS + 1];
 
+namespace {
 extern addrbank pci_config_bank, pci_io_bank, pci_mem_bank, pci_bridge_bank;
+}
 
 static void pci_board_free(struct pci_board_state *pcibs)
 {
@@ -1461,34 +1463,36 @@ static void REGPARAM2 pci_bridge_lput_2(uaecptr addr, uae_u32 b)
 	pci_bridge_wput_2(addr + 2, b >>  0);
 }
 
-static addrbank pci_config_bank = {
+namespace {
+addrbank pci_config_bank = {
 	pci_config_lget, pci_config_wget, pci_config_bget,
 	pci_config_lput, pci_config_wput, pci_config_bput,
 	default_xlate, default_check, NULL, NULL, _T("PCI CONFIG"),
 	pci_config_lget, pci_config_wget,
 	ABFLAG_IO | ABFLAG_SAFE, S_READ, S_WRITE
 };
-static addrbank pci_io_bank = {
+addrbank pci_io_bank = {
 	pci_io_lget, pci_io_wget, pci_io_bget,
 	pci_io_lput, pci_io_wput, pci_io_bput,
 	default_xlate, default_check, NULL, NULL, _T("PCI IO"),
 	pci_io_lget, pci_io_wget,
 	ABFLAG_IO | ABFLAG_SAFE, S_READ, S_WRITE
 };
-static addrbank pci_mem_bank = {
+addrbank pci_mem_bank = {
 	pci_mem_lget, pci_mem_wget, pci_mem_bget,
 	pci_mem_lput, pci_mem_wput, pci_mem_bput,
 	default_xlate, default_check, NULL, NULL, _T("PCI MEMORY"),
 	pci_mem_lget, pci_mem_wget,
 	ABFLAG_IO | ABFLAG_SAFE, S_READ, S_WRITE
 };
-static addrbank pci_bridge_bank = {
+addrbank pci_bridge_bank = {
 	pci_bridge_lget, pci_bridge_wget, pci_bridge_bget,
 	pci_bridge_lput, pci_bridge_wput, pci_bridge_bput,
 	default_xlate, default_check, NULL, NULL, _T("PCI BRIDGE"),
 	pci_bridge_lget, pci_bridge_wget,
 	ABFLAG_IO | ABFLAG_SAFE, S_READ, S_WRITE
 };
+}
 static addrbank pci_bridge_bank_2 = {
 	pci_bridge_lget_2, pci_bridge_wget_2, pci_bridge_bget_2,
 	pci_bridge_lput_2, pci_bridge_wput_2, pci_bridge_bput_2,

--- a/x86.cpp
+++ b/x86.cpp
@@ -3569,11 +3569,24 @@ int device_get_config_int(const char *s)
 	if (!strcmp(s, "dithering")) {
 		return 1;
 	}
+	if (!strcmp(s, "dithersub")) {
+		return 1;
+	}
 	if (!strcmp(s, "dacfilter")) {
 		return 1;
 	}
 	if (!strcmp(s, "recompiler")) {
+#ifdef _WIN32
 		return 1;
+#else
+		return 0;
+#endif
+	}
+	if (!strcmp(s, "sli") || !strcmp(s, "type")) {
+		return 0;
+	}
+	if (!strcmp(s, "framebuffer_memory") || !strcmp(s, "texture_memory")) {
+		return 2;
 	}
 	if (!strcmp(s, "memory")) {
 		return pcem_getvramsize() >> 20;

--- a/x86.cpp
+++ b/x86.cpp
@@ -3576,7 +3576,7 @@ int device_get_config_int(const char *s)
 		return 1;
 	}
 	if (!strcmp(s, "recompiler")) {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(PCEM_VOODOO_CODEGEN)
 		return 1;
 #else
 		return 0;


### PR DESCRIPTION
This series fixes the imported PCem bridgeboard integration used by the WinUAE build.

The PCem-source portability pieces are split by provenance:

- MGA high-bit masks and Voodoo dynamic `offsetof()` cleanup mirror fixes already merged upstream in 86Box as https://github.com/86Box/86Box/pull/7222.
- The remaining PCem changes are WinUAE embedding glue: helper thread handles, C++ build fixes for imported graphics files, UAE build guards/defaults, MIDI byte typing, and hiding unused CPU catalog declarations that collide with the embedded bridgeboard glue.

There is also one non-PCem generic fix: `pci.cpp` keeps bridge memory bank declarations private while declaring them before first use for compilers that require declarations before use.