### PR TITLE
slirp: fix Unix portability and socket handling

### DIFF
--- a/slirp/icmp_var.h
+++ b/slirp/icmp_var.h
@@ -61,7 +61,7 @@ struct icmpstat {
 }
 
 extern struct icmpstat icmpstat;
-#if 0
+#if SLIRP_ICMP
 extern struct socket icmp; 
 extern struct socket *icmp_last_so;
 #endif

--- a/slirp/ip_icmp.cpp
+++ b/slirp/ip_icmp.cpp
@@ -88,6 +88,7 @@ static int icmp_send(struct socket *so, struct mbuf *m, int hlen)
     if (so->s == -1) {
         return -1;
     }
+    fd_nonblock(so->s);
 
     so->so_m = m;
     so->so_faddr = ip->ip_dst;
@@ -164,9 +165,9 @@ void icmp_input(struct mbuf *m, int hlen)
   DEBUG_ARG("icmp_type = %d", icp->icmp_type);
   switch (icp->icmp_type) {
   case ICMP_ECHO:
-    icp->icmp_type = ICMP_ECHOREPLY;
     ip->ip_len += hlen;	             /* since ip_input subtracts this */
     if (ip->ip_dst.s_addr == alias_addr.s_addr) {
+      icp->icmp_type = ICMP_ECHOREPLY;
       icmp_reflect(m);
     } else {
       struct socket *so;
@@ -176,6 +177,7 @@ void icmp_input(struct mbuf *m, int hlen)
 	  if (icmp_send(so, m, hlen) == 0)
         return;
 #endif
+	  icp->icmp_type = ICMP_ECHOREPLY;
 	  if(udp_attach(so) == -1) {
 	DEBUG_MISC(("icmp_input udp_attach errno = %d-%s\n", 
 		    errno,strerror(errno)));
@@ -431,6 +433,7 @@ void icmp_receive(struct socket *so)
     int hlen = ip->ip_hl << 2;
     u_char error_code;
     struct icmp *icp;
+    uae_u8 reply[2048];
     int id, len;
 
     m->m_data += hlen;
@@ -438,8 +441,40 @@ void icmp_receive(struct socket *so)
     icp = mtod(m, struct icmp *);
 
     id = icp->icmp_id;
-    len = recv(so->s, (char*)icp, m->m_len, 0);
-    icp->icmp_id = id;
+    len = recv(so->s, (char*)reply, sizeof(reply), 0);
+    if (len > 0) {
+        int offset = 0;
+        int reply_len;
+
+        if (len >= (int)sizeof(struct ip) && (reply[0] >> 4) == 4) {
+            int iphlen = (reply[0] & 0x0f) << 2;
+            struct ip *reply_ip = (struct ip*)reply;
+            if (iphlen >= (int)sizeof(struct ip) && iphlen <= len &&
+                reply_ip->ip_p == IPPROTO_ICMP) {
+                offset = iphlen;
+            }
+        }
+
+        reply_len = len - offset;
+        if (reply_len <= 0) {
+            errno = EPROTO;
+            len = -1;
+        } else {
+            if ((size_t)reply_len > M_ROOM(m)) {
+                char *base = (m->m_flags & M_EXT) ? m->m_ext : m->m_dat;
+                m_inc(m, (int)(m->m_data - base + reply_len));
+            }
+            if ((size_t)reply_len > M_ROOM(m)) {
+                errno = ENOMEM;
+                len = -1;
+            } else {
+                memcpy(m->m_data, reply + offset, reply_len);
+                m->m_len = reply_len;
+                icp = mtod(m, struct icmp *);
+                icp->icmp_id = id;
+            }
+        }
+    }
 
     m->m_data -= hlen;
     m->m_len += hlen;

--- a/slirp/slirp.cpp
+++ b/slirp/slirp.cpp
@@ -302,7 +302,7 @@ int slirp_select_fill(INT_PTR *pnfds,
 			}
 		}
 
-#if 0
+#if SLIRP_ICMP
         /*
          * ICMP sockets
          */
@@ -533,7 +533,7 @@ void slirp_select_poll(fd_set *readfds, fd_set *writefds, fd_set *xfds)
 			}
 		}
 
-#if 0
+#if SLIRP_ICMP
         /*
          * Check incoming ICMP relies.
          */

--- a/slirp/slirp.cpp
+++ b/slirp/slirp.cpp
@@ -450,21 +450,20 @@ void slirp_select_poll(fd_set *readfds, fd_set *writefds, fd_set *xfds)
 				 * Check for non-blocking, still-connecting sockets
 				 */
 				if (so->so_state & SS_ISFCONNECTING) {
-					/* Connected */
-					so->so_state &= ~SS_ISFCONNECTING;
-
-					ret = send(so->s, (const char*)&ret, 0, 0);
-					if (ret < 0) {
-						/* XXXXX Must fix, zero bytes is a NOP */
-						int error = WSAGetLastError();
-						if (error == EAGAIN || error == WSAEWOULDBLOCK  ||
-							error == WSAEINPROGRESS  || error == WSAENOTCONN)
+					int error = 0;
+					socklen_t error_len = sizeof(error);
+					if (getsockopt(so->s, SOL_SOCKET, SO_ERROR,
+						(char*)&error, &error_len) < 0)
+						error = WSAGetLastError();
+					if (error) {
+						if (error == EAGAIN || error == WSAEWOULDBLOCK ||
+							error == WSAEINPROGRESS || error == WSAENOTCONN)
 							continue;
-			      
 						/* else failed */
 						so->so_state = SS_NOFDREF;
+					} else {
+						so->so_state &= ~SS_ISFCONNECTING;
 					}
-					/* else so->so_state &= ~SS_ISFCONNECTING; */
 
 					/*
 					 * Continue tcp_input

--- a/slirp/slirp.h
+++ b/slirp/slirp.h
@@ -81,6 +81,10 @@ typedef int ioctlsockopt_t;
 # include <stdint.h>
 #endif
 
+#ifndef container_of
+#define container_of(address, type, field) ((type *)((char *)(address) - (uintptr_t)(&((type *)0)->field)))
+#endif
+
 #ifdef NEED_TYPEDEFS
 typedef char int8_t;
 typedef unsigned char u_int8_t;

--- a/slirp/slirp.h
+++ b/slirp/slirp.h
@@ -11,7 +11,7 @@
 #include "sysconfig.h"
 #include "slirp_config.h"
 
-#define SLIRP_ICMP 0
+#define SLIRP_ICMP 1
 
 #ifdef _WIN32
 #include <stdint.h>

--- a/slirp/slirp_config.h
+++ b/slirp/slirp_config.h
@@ -92,6 +92,9 @@
 
 /* Define if you have index() */
 #undef HAVE_INDEX
+#ifndef _WIN32
+#define HAVE_INDEX
+#endif
 
 /* Define if you have bcmp() */
 #undef HAVE_BCMP

--- a/slirp/socket.cpp
+++ b/slirp/socket.cpp
@@ -397,6 +397,8 @@ void sorecvfrom(struct socket *so)
 	    u_char code=ICMP_UNREACH_PORT;
 
 		int error = WSAGetLastError();
+	    if(len == -1 && IS_EAGAIN(error))
+	      return;
 	    if(error  == WSAEHOSTUNREACH) code=ICMP_UNREACH_HOST;
 	    else if(error  == WSAENETUNREACH) code=ICMP_UNREACH_NET;
 	    
@@ -440,6 +442,10 @@ void sorecvfrom(struct socket *so)
 	    u_char code=ICMP_UNREACH_PORT;
 		int error = WSAGetLastError();
 
+	    if (IS_EAGAIN(error)) {
+	      m_free(m);
+	      return;
+	    }
 	    if(error == WSAEHOSTUNREACH) code=ICMP_UNREACH_HOST;
 	    else if(error == WSAENETUNREACH) code=ICMP_UNREACH_NET;
 	    

--- a/slirp/udp.cpp
+++ b/slirp/udp.cpp
@@ -334,6 +334,7 @@ SLIRP_SOCKET udp_attach(struct socket *so)
 	 * (sendto() on an unbound socket will bind it), it's done
 	 * here so that emulation of ytalk etc. don't have to do it
 	 */
+		fd_nonblock(so->s);
 		memset(&addr, 0, sizeof(struct sockaddr_in));
 		addr.sin_family = AF_INET;
 		addr.sin_port = 0;

--- a/slirp_uae.cpp
+++ b/slirp_uae.cpp
@@ -135,6 +135,7 @@ int uae_slirp_redir(int is_udp, int host_port, struct in_addr guest_addr,
 
 static volatile int slirp_thread_active;
 static uae_thread_id slirp_tid;
+static bool slirp_thread_started;
 extern uae_sem_t slirp_sem2;
 
 static void slirp_receive_func(void *arg)
@@ -203,8 +204,14 @@ bool uae_slirp_start (void)
 #ifdef WITH_BUILTIN_SLIRP
 	if (impl == BUILTIN_IMPLEMENTATION) {
 		uae_slirp_end ();
-		uae_start_thread(_T("slirp-receive"), slirp_receive_func, NULL,
-						 &slirp_tid);
+		slirp_thread_active = 1;
+		if (!uae_start_thread(_T("slirp-receive"), slirp_receive_func, NULL,
+						 &slirp_tid)) {
+			slirp_thread_active = 0;
+			slirp_thread_started = false;
+			return false;
+		}
+		slirp_thread_started = true;
 		return true;
 	}
 #endif
@@ -221,20 +228,10 @@ void uae_slirp_end(void)
 #endif
 #ifdef WITH_BUILTIN_SLIRP
 	if (impl == BUILTIN_IMPLEMENTATION) {
-		if (slirp_thread_active > 0) {
+		if (slirp_thread_started) {
 			slirp_thread_active = 0;
-			// Use a proper timeout instead of infinite waiting
-			int wait_count = 0;
-			while (slirp_thread_active == 0 && wait_count < 100) {
-				sleep_millis(10);
-				wait_count++;
-			}
-
-			// Force thread termination if it didn't exit cleanly
-			if (slirp_thread_active == 0) {
-				write_log(_T("SLIRP thread did not terminate properly, forcing exit\n"));
-			}
-			uae_end_thread(&slirp_tid);
+			uae_wait_thread(slirp_tid);
+			slirp_thread_started = false;
 		}
 		slirp_thread_active = 0;
 		return;


### PR DESCRIPTION
This series keeps the bundled SLIRP backend usable on non-Windows hosts and fixes a few socket handling issues in the old in-tree SLIRP code.

Changes included:

  - Add small Unix libc compatibility fallbacks:
      - provide container_of
      - avoid redeclaring libc index() on Unix hosts
  - Enable ICMP forwarding through datagram sockets:
      - keep ICMP sockets nonblocking
      - include ICMP sockets in the SLIRP select loop
      - strip host IPv4 headers before returning ICMP replies to the guest
  - Fix nonblocking TCP connect completion:
      - use getsockopt(SO_ERROR) after select() reports writability
      - keep still-pending connects pending
      - only clear SS_ISFCONNECTING once the socket has completed cleanly
  - Avoid using a Unix thread sentinel in shared code:
      - track whether the SLIRP helper thread was actually started
      - avoid writing BAD_THREAD into uae_thread_id, which is not portable to Windows HANDLE-backed thread IDs
