### PR TITLE
qemuvga: make glue header usable on Unix

### DIFF
--- a/qemuvga/qemuuaeglue.h
+++ b/qemuvga/qemuuaeglue.h
@@ -2,7 +2,11 @@
 #include "uae/likely.h"
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#ifndef _MSC_VER
+#include <sys/types.h>
+#endif
 #include "sysconfig.h"
 
 #ifdef DEBUGGER
@@ -21,7 +25,9 @@ extern void write_log (const char *, ...);
 #define tostring(s)	#s
 #endif
 
+#ifdef _MSC_VER
 typedef int ssize_t;
+#endif
 
 #ifdef _MSC_VER
 #include <windows.h>
@@ -405,4 +411,3 @@ extern uint64_t lsi_mmio_read(void *opaque, hwaddr addr, unsigned size);
 
 typedef void *qemu_irq;
 typedef void* SysBusDevice;
-


### PR DESCRIPTION
Include the standard Unix type declarations needed by qemuuaeglue.h and keep the local ssize_t typedef restricted to MSVC builds.