### PR TITLE
clipboard: expose host text polling hook

### DIFF
--- a/include/clipboard.h
+++ b/include/clipboard.h
@@ -12,5 +12,6 @@ extern void amiga_clipboard_task_start(TrapContext *ctx, uaecptr);
 extern void clipboard_disable(bool);
 extern void clipboard_vsync(void);
 extern void clipboard_unsafeperiod(void);
+extern void clipboard_host_changed(void);
 
 #endif /* UAE_CLIPBOARD_H */


### PR DESCRIPTION
Add the shared clipboard hook used by targets that can poll native host clipboard text.