### PR TITLE
fsdb: update Unix fsdb API glue

### DIFF
--- a/fsdb_unix.cpp
+++ b/fsdb_unix.cpp
@@ -11,10 +11,11 @@
 #include "sysconfig.h"
 #include "sysdeps.h"
 
+#include "uae.h"
 #include "fsdb.h"
 
 /* Return nonzero for any name we can't create on the native filesystem.  */
-int fsdb_name_invalid (const char *n)
+static int fsdb_name_invalid_name (const TCHAR *n)
 {
     if (strcmp (n, FSDB_FILE) == 0)
 	return 1;
@@ -25,9 +26,29 @@ int fsdb_name_invalid (const char *n)
     return n[1] == '.' && n[2] == '\0';
 }
 
+int fsdb_name_invalid (a_inode *, const TCHAR *n)
+{
+    return fsdb_name_invalid_name(n);
+}
+
+int fsdb_name_invalid_dir (a_inode *aino, const TCHAR *n)
+{
+    return fsdb_name_invalid(aino, n);
+}
+
+int fsdb_exists (const TCHAR *nname)
+{
+    return nname && access(nname, F_OK) == 0;
+}
+
+int same_aname (const TCHAR *an1, const TCHAR *an2)
+{
+    return an1 && an2 && !_tcsicmp(an1, an2);
+}
+
 /* For an a_inode we have newly created based on a filename we found on the
  * native fs, fill in information about this file/directory.  */
-int fsdb_fill_file_attrs (a_inode *aino)
+int fsdb_fill_file_attrs (a_inode *, a_inode *aino)
 {
     struct stat statbuf;
     /* This really shouldn't happen...  */
@@ -40,7 +61,7 @@ int fsdb_fill_file_attrs (a_inode *aino)
     return 1;
 }
 
-int fsdb_set_file_attrs (a_inode *aino, int mask)
+int fsdb_set_file_attrs (a_inode *aino)
 {
     struct stat statbuf;
     int mode;
@@ -51,17 +72,17 @@ int fsdb_set_file_attrs (a_inode *aino, int mask)
     mode = statbuf.st_mode;
     /* Unix dirs behave differently than AmigaOS ones.  */
     if (! aino->dir) {
-	if (mask & A_FIBF_READ)
+	if (aino->amigaos_mode & A_FIBF_READ)
 	    mode &= ~S_IRUSR;
 	else
 	    mode |= S_IRUSR;
 
-	if (mask & A_FIBF_WRITE)
+	if (aino->amigaos_mode & A_FIBF_WRITE)
 	    mode &= ~S_IWUSR;
 	else
 	    mode |= S_IWUSR;
 
-	if (mask & A_FIBF_EXECUTE)
+	if (aino->amigaos_mode & A_FIBF_EXECUTE)
 	    mode &= ~S_IXUSR;
 	else
 	    mode |= S_IXUSR;
@@ -69,18 +90,56 @@ int fsdb_set_file_attrs (a_inode *aino, int mask)
 	chmod (aino->nname, mode);
     }
 
-    aino->amigaos_mode = mask;
     aino->dirty = 1;
     return 0;
 }
 
 /* Return nonzero if we can represent the amigaos_mode of AINO within the
  * native FS.  Return zero if that is not possible.  */
-int fsdb_mode_representable_p (const a_inode *aino)
+int fsdb_mode_representable_p (const a_inode *aino, int amigaos_mode)
 {
     if (aino->dir)
-	return aino->amigaos_mode == 0;
-    return (aino->amigaos_mode & (A_FIBF_DELETE | A_FIBF_SCRIPT | A_FIBF_PURE)) == 0;
+	return amigaos_mode == 0;
+    return (amigaos_mode & (A_FIBF_DELETE | A_FIBF_SCRIPT | A_FIBF_PURE)) == 0;
+}
+
+int fsdb_mode_supported (const a_inode *aino)
+{
+    return fsdb_mode_representable_p(aino, aino->amigaos_mode) ? aino->amigaos_mode : 0;
+}
+
+TCHAR *fsdb_search_dir (const TCHAR *dirname, TCHAR *rel, TCHAR **relalt)
+{
+    if (relalt) {
+	*relalt = NULL;
+    }
+    TCHAR *tmp = build_nname(dirname, rel);
+    if (!tmp) {
+	return NULL;
+    }
+    if (fsdb_exists(tmp)) {
+	xfree(tmp);
+	return rel;
+    }
+    xfree(tmp);
+
+    DIR *dir = opendir(dirname);
+    if (!dir) {
+	return NULL;
+    }
+    TCHAR *match = NULL;
+    for (;;) {
+	struct dirent *de = readdir(dir);
+	if (!de) {
+	    break;
+	}
+	if (same_aname(de->d_name, rel)) {
+	    match = !_tcscmp(de->d_name, rel) ? rel : my_strdup(de->d_name);
+	    break;
+	}
+    }
+    closedir(dir);
+    return match;
 }
 
 char *fsdb_create_unique_nname (a_inode *base, const char *suggestion)


### PR DESCRIPTION
Update the Unix fsdb compatibility layer to match the current shared fsdb API.

The Unix implementation had drifted from the shared fsdb entry points and still used older helper signatures in a few places. Add the missing glue and adapt the existing calls so the Unix target can use the same fsdb interfaces as the rest of the tree.

This is intended to be a target glue update only. It does not change the Windows fsdb implementation.
