### PR TITLE
Add shared declarations for Unix networking backends.

### DIFF
--- a/ethernet.cpp
+++ b/ethernet.cpp
@@ -3,8 +3,8 @@
 #include "sysdeps.h"
 
 #include "ethernet.h"
-#ifdef _WIN32
-#include "win32_uaenet.h"
+#ifdef WITH_UAENET_PCAP
+#include "uaenet.h"
 #endif
 #include "threaddep/thread.h"
 #include "options.h"

--- a/ethernet.cpp
+++ b/ethernet.cpp
@@ -99,6 +99,8 @@ void ethernet_trigger (struct netdriverdata *ndd, void *vsd)
 #endif
 #ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
+		case UAENET_TAP:
+		case UAENET_TUN:
 		uaenet_trigger (vsd);
 		return;
 #endif
@@ -160,6 +162,8 @@ int ethernet_open (struct netdriverdata *ndd, void *vsd, void *user, ethernet_go
 #endif
 #ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
+		case UAENET_TAP:
+		case UAENET_TUN:
 		if (uaenet_open (vsd, ndd, user, gotfunc, getfunc, promiscuous, mac)) {
 			netmode = ndd->type;
 			return 1;
@@ -190,6 +194,8 @@ void ethernet_close (struct netdriverdata *ndd, void *vsd)
 #endif
 #ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
+		case UAENET_TAP:
+		case UAENET_TUN:
 		return uaenet_close (vsd);
 #endif
 	}
@@ -257,6 +263,8 @@ void ethernet_close_driver (struct netdriverdata *ndd)
 		return;
 #ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
+		case UAENET_TAP:
+		case UAENET_TUN:
 		return uaenet_close_driver (ndd);
 #endif
 	}
@@ -272,6 +280,8 @@ int ethernet_getdatalenght (struct netdriverdata *ndd)
 		return sizeof (struct ethernet_data);
 #ifdef WITH_UAENET_PCAP
 		case UAENET_PCAP:
+		case UAENET_TAP:
+		case UAENET_TUN:
 		return uaenet_getdatalenght ();
 #endif
 	}

--- a/include/bsdsocket.h
+++ b/include/bsdsocket.h
@@ -17,6 +17,8 @@
 
 extern int log_bsd;
 
+typedef struct TrapContext TrapContext;
+
 #define ISBSDTRACE (log_bsd || BSD_TRACING_ENABLED) 
 #define BSDTRACE(x) do { if (ISBSDTRACE) { write_log x; } } while(0)
 
@@ -35,6 +37,10 @@ extern void deinit_socket_layer (void);
 #ifdef _WIN32
 #define SOCKET_TYPE SOCKET
 #else
+#ifndef INVALID_SOCKET
+#define INVALID_SOCKET (-1)
+#endif
+typedef int SOCKET;
 #define SOCKET_TYPE int
 #endif
 
@@ -97,6 +103,7 @@ struct socketbase {
     uae_u32 sets [3];
     uae_u32 timeout;
     uae_u32 sigmp;
+    TrapContext *context;
 #endif
 };
 

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -7,6 +7,8 @@
 #define UAENET_SLIRP 1
 #define UAENET_SLIRP_INBOUND 2
 #define UAENET_PCAP 3
+#define UAENET_TAP 4
+#define UAENET_TUN 5
 
 struct netdriverdata
 {

--- a/include/uaenet.h
+++ b/include/uaenet.h
@@ -1,0 +1,18 @@
+#ifndef UAE_UAENET_H
+#define UAE_UAENET_H
+
+#include "ethernet.h"
+
+typedef void (uaenet_gotfunc)(void *dev, const uae_u8 *data, int len);
+typedef int (uaenet_getfunc)(void *dev, uae_u8 *d, int *len);
+
+extern struct netdriverdata *uaenet_enumerate(const TCHAR *name);
+extern void uaenet_enumerate_free(void);
+extern void uaenet_close_driver(struct netdriverdata *tc);
+
+extern int uaenet_getdatalenght(void);
+extern int uaenet_open(void*, struct netdriverdata*, void*, uaenet_gotfunc*, uaenet_getfunc*, int, const uae_u8*);
+extern void uaenet_close(void*);
+extern void uaenet_trigger(void*);
+
+#endif /* UAE_UAENET_H */


### PR DESCRIPTION
This exposes the target-provided bsdsocket hooks, adds the Unix packet backend entry points used by the Ethernet code, and reserves TAP/TUN backend slots so the shared network configuration can enumerate those modes.

The platform implementations remain in target code. Windows behavior is unchanged.
