### PR TITLE
Guard indirect autoconfig RAM allocation in `mapped_malloc()`.

### DIFF
--- a/memory.cpp
+++ b/memory.cpp
@@ -2332,7 +2332,7 @@ bool mapped_malloc (addrbank *ab)
 	ab->baseaddr_direct_w = NULL;
 	ab->flags &= ~ABFLAG_MAPPED;
 
-	if (ab->label && ab->label[0] == '*') {
+	if (canbang && ab->label && ab->label[0] == '*') {
 		if (ab->start == 0 || ab->start == 0xffffffff) {
 			write_log(_T("mapped_malloc(*) without start address!\n"));
 			return false;


### PR DESCRIPTION
The indirect allocation path is selected by labels starting with `*`, but that path also requires the caller to opt in through `canbang`. Without that guard, ordinary mappings can enter the indirect allocation handling because of label text alone.

This keeps indirect allocation behavior limited to callers that explicitly allow it.
