### PR TITLE
Avoid a lock ordering inversion when injecting PPC external interrupts into QEMU.

### DIFF
--- a/ppc/ppc.cpp
+++ b/ppc/ppc.cpp
@@ -939,7 +939,7 @@ void uae_ppc_interrupt(bool active)
 		return;
 	}
 
-	PPCLockStatus status = get_ppc_lock(PPC_KEEP_SPINLOCK);
+	PPCLockStatus status = get_ppc_lock(PPC_RELEASE_SPINLOCK);
 	impl.external_interrupt(active);
 	release_ppc_lock(status);
 }


### PR DESCRIPTION
QEMU 10 and newer take the BQL inside ppc_set_irq(). The external interrupt path can call into QEMU while still holding the UAE PPC spinlock.

That can deadlock if the main thread waits for QEMU BQL while the QEMU CPU thread waits for the UAE spinlock.

Use the release-spinlock path for external interrupt injection. This matches the ordering used for QEMU memory mapping and state changes.