### PR TITLE
Clean up Pro-Wizard   host declarations

### DIFF
--- a/prowizard/include/extern.h
+++ b/prowizard/include/extern.h
@@ -356,12 +356,6 @@ extern char Extensions[_KNOWN_FORMATS+1][33];
 extern Uchar CONVERT;
 extern Uchar Amiga_EXE_Header;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 extern void pw_write_log (const char *, ...);
 extern FILE *moduleripper2_fopen (const char *name, const char *mode, const char *aid, int addr, int size);
 extern FILE *moduleripper_fopen (const char *aname, const char *amode);
-#ifdef __cplusplus
-}
-#endif

--- a/prowizard/include/extern.h
+++ b/prowizard/include/extern.h
@@ -332,7 +332,9 @@ extern short test_smps ( long, long, long, Uchar, Uchar );
 extern long  PWGetFileSize ( char * );
 extern FILE * PW_fopen ( char *, char * );
 extern void fillPTKtable ( Uchar[37][2] );
+#ifndef htonl
 extern unsigned int htonl(unsigned int);
+#endif
 
 /* globals */
 /* Some say it's badly coding when using Globals ... sure it is, now what's the solution ? */

--- a/prowizard/include/globals.h
+++ b/prowizard/include/globals.h
@@ -26,6 +26,10 @@ __inline Ulong htonlx (Ulong v)
 {
     return (v >> 24) | ((v >> 8) & 0xff00) | (v << 24) | ((v << 8) & 0xff0000);
 }
+#else
+#ifndef _cdecl
+#define _cdecl
+#endif
 #endif
 
 #define _KNOWN_FORMATS      135

--- a/prowizard/misc/misc.c
+++ b/prowizard/misc/misc.c
@@ -508,7 +508,9 @@ void fillPTKtable (Uchar poss[37][2])
   return;
 }
 
+#ifndef htonl
 unsigned int htonl(unsigned int v)
 {
 	return ((v >> 24) & 0x000000ff) | ((v >> 8) & 0x0000ff00) | ((v << 8) & 0x00ff0000) | ((v << 24) & 0xff000000);
 }
+#endif


### PR DESCRIPTION
## Summary
 
Clean up shared Pro-Wizard declarations so they build consistently in host builds without changing the Windows-style C++ callback linkage.
 
## Details
 
  - Avoid redeclaring `htonl` when host headers already provide it.
  - Provide a no-op `_cdecl` definition for non-Windows builds.
  - Drop the stale `extern "C"` guard around the module-ripper callback declarations.
 
The Pro-Wizard sources are built as C++ on Windows, so host callbacks should keep normal C++ linkage. Non-Windows builds should match that by compiling Pro-Wizard as C++ rather than forcing C linkage in the shared header.
