### PR TITLE
Fix serial socket creation so that it works under WINE

### DIFF
--- a/od-win32/parser.cpp
+++ b/od-win32/parser.cpp
@@ -973,6 +973,11 @@ static int opentcp (const TCHAR *sername)
 	bool waitmode = false;
 	const int one = 1;
 	const struct linger linger_1s = { 1, 1 };
+	ADDRINFOW hints = {0};
+
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
 
 	if (WSAStartup (MAKEWORD (2, 2), &wsadata)) {
 		DWORD lasterror = WSAGetLastError ();
@@ -999,7 +1004,7 @@ static int opentcp (const TCHAR *sername)
 	if (!port)
 		port = 	my_strdup (_T("1234"));
 
-	err = GetAddrInfoW (name, port, NULL, &socketinfo);
+	err = GetAddrInfoW (name, port, &hints, &socketinfo);
 	if (err < 0) {
 		write_log (_T("SERIAL_TCP: GetAddrInfoW() failed, %s:%s: %d\n"), name, port, WSAGetLastError ());
 		goto end;


### PR DESCRIPTION
Fix TCP serial server socket creation failing under WINE on Linux and macOS.

Passing NULL hints to GetAddrInfoW causes it to return ai_socktype=0 and ai_protocol=0 in the result. On native Windows, socket() tolerates these zero values, but WINE passes them straight through to the host kernel which rejects socktype=0 with EINVAL, causing socket() to fail and the subsequent bind() to fail on an invalid socket.

Fix by passing explicit hints (AF_INET, SOCK_STREAM, IPPROTO_TCP) to GetAddrInfoW, which also ensures a consistent AF_INET result regardless of the host system's address resolution ordering.