### PR TITLE
Harden SLIRP backend teardown and restart handling

### DIFF
--- a/ethernet.cpp
+++ b/ethernet.cpp
@@ -122,7 +122,12 @@ int ethernet_open (struct netdriverdata *ndd, void *vsd, void *user, ethernet_go
 			slirp_data = ed;
 			uae_sem_init (&slirp_sem1, 0, 1);
 			uae_sem_init (&slirp_sem2, 0, 1);
-			uae_slirp_init();
+			if (uae_slirp_init() < 0) {
+				slirp_data = NULL;
+				uae_sem_destroy (&slirp_sem1);
+				uae_sem_destroy (&slirp_sem2);
+				return 0;
+			}
 			for (int i = 0; i < MAX_SLIRP_REDIRS; i++) {
 				struct slirp_redir *sr = &currprefs.slirp_redirs[i];
 				if (sr->proto) {
@@ -156,7 +161,13 @@ int ethernet_open (struct netdriverdata *ndd, void *vsd, void *user, ethernet_go
 				}
 			}
 			netmode = ndd->type;
-			uae_slirp_start ();
+			if (!uae_slirp_start ()) {
+				uae_slirp_cleanup ();
+				slirp_data = NULL;
+				uae_sem_destroy (&slirp_sem1);
+				uae_sem_destroy (&slirp_sem2);
+				return 0;
+			}
 		}
 		return 1;
 #endif
@@ -184,9 +195,9 @@ void ethernet_close (struct netdriverdata *ndd, void *vsd)
 		case UAENET_SLIRP:
 		case UAENET_SLIRP_INBOUND:
 		if (slirp_data) {
-			slirp_data = NULL;
 			uae_slirp_end ();
 			uae_slirp_cleanup ();
+			slirp_data = NULL;
 			uae_sem_destroy (&slirp_sem1);
 			uae_sem_destroy (&slirp_sem2);
 		}

--- a/slirp/bootp.cpp
+++ b/slirp/bootp.cpp
@@ -40,6 +40,11 @@ BOOTPClient bootp_clients[NB_ADDR];
 
 static const uint8_t rfc1533_cookie[] = { RFC1533_COOKIE };
 
+void bootp_reset(void)
+{
+    memset(bootp_clients, 0, sizeof bootp_clients);
+}
+
 static BOOTPClient *get_new_addr(struct in_addr *paddr)
 {
     BOOTPClient *bc;
@@ -144,10 +149,15 @@ static void bootp_reply(struct bootp_t *bp)
     memset(rbp, 0, sizeof(struct bootp_t));
 
     if (dhcp_msg_type == DHCPDISCOVER) {
+        bc = find_addr(&daddr.sin_addr, bp->bp_hwaddr);
+        if (bc)
+            goto have_addr;
     new_addr:
         bc = get_new_addr(&daddr.sin_addr);
-        if (!bc)
+        if (!bc) {
+            m_free(m);
             return;
+        }
         memcpy(bc->macaddr, client_ethaddr, 6);
     } else {
         bc = find_addr(&daddr.sin_addr, bp->bp_hwaddr);
@@ -157,6 +167,7 @@ static void bootp_reply(struct bootp_t *bp)
             goto new_addr;
         }
     }
+have_addr:
 
     saddr.sin_addr.s_addr = htonl(ntohl(special_addr.s_addr) | CTL_ALIAS);
     saddr.sin_port = htons(BOOTP_SERVER);

--- a/slirp/bootp.h
+++ b/slirp/bootp.h
@@ -113,3 +113,4 @@ struct bootp_t {
 #include "unpacked.h"
 
 void bootp_input(struct mbuf *m);
+void bootp_reset(void);

--- a/slirp/slirp.cpp
+++ b/slirp/slirp.cpp
@@ -137,6 +137,7 @@ int slirp_init(void)
 
     link_up = 1;
 
+    bootp_reset();
     if_init();
     ip_init();
 
@@ -159,6 +160,7 @@ void slirp_cleanup(void)
 {
     ip_cleanup();
     m_cleanup();
+	bootp_reset();
 	link_up = 0;
 }
 

--- a/slirp_uae.cpp
+++ b/slirp_uae.cpp
@@ -61,7 +61,7 @@ int uae_slirp_init(void)
 
 #ifdef WITH_QEMU_SLIRP
 	if (impl == QEMU_IMPLEMENTATION) {
-		return uae_qemu_uae_init() == NULL;
+		return uae_qemu_uae_init() ? 0 : -1;
 	}
 #endif
 #ifdef WITH_BUILTIN_SLIRP
@@ -140,7 +140,6 @@ extern uae_sem_t slirp_sem2;
 
 static void slirp_receive_func(void *arg)
 {
-	slirp_thread_active = 1;
 	while (slirp_thread_active == 1) {
 		fd_set rfds, wfds, xfds;
 		INT_PTR nfds;


### PR DESCRIPTION
Ariadne can close and reopen the selected Ethernet backend while guest software probes or retries card configuration. The SLIRP backend currently tears down callback state before the receive thread is known to be stopped, and it does not propagate initialization or thread startup failures.

## Details

  - Keep callback state alive until SLIRP shutdown has completed.
  - Join the receive thread before cleanup.
  - Return failure when SLIRP initialization or receive-thread startup fails.
  - Reset BOOTP leases during SLIRP init and cleanup.
  - Reuse an existing BOOTP lease for repeat DHCPDISCOVER requests from the same client MAC address.
