### PR TITLE
Add non-Windows sound-board capture hooks

### DIFF
--- a/sndboard.cpp
+++ b/sndboard.cpp
@@ -42,8 +42,6 @@ static void sndboard_reset(int hardreset);
 
 static float base_event_clock;
 
-extern addrbank uaesndboard_bank_z2, uaesndboard_bank_z3;
-
 #define MAX_DUPLICATE_SOUND_BOARDS 1
 #define MAX_SNDDEVS 3
 
@@ -257,8 +255,7 @@ static struct uaesndboard_data uaesndboard[MAX_DUPLICATE_SOUND_BOARDS];
 
 static bool audio_state_sndboard_uae(int streamid, void *params);
 
-extern addrbank uaesndboard_ram_bank;
-MEMORY_FUNCTIONS(uaesndboard_ram);
+DECLARE_MEMORY_FUNCTIONS(uaesndboard_ram);
 static addrbank uaesndboard_ram_bank = {
 	uaesndboard_ram_lget, uaesndboard_ram_wget, uaesndboard_ram_bget,
 	uaesndboard_ram_lput, uaesndboard_ram_wput, uaesndboard_ram_bput,
@@ -266,6 +263,7 @@ static addrbank uaesndboard_ram_bank = {
 	uaesndboard_ram_lget, uaesndboard_ram_wget,
 	ABFLAG_RAM | ABFLAG_THREADSAFE, 0, 0
 };
+MEMORY_FUNCTIONS(uaesndboard_ram);
 
 static bool uaesnd_rethink(void)
 {
@@ -909,6 +907,43 @@ static void uaesnd_configure(struct uaesndboard_data *data)
 	}
 }
 
+static uae_u32 REGPARAM3 uaesndboard_lget(uaecptr) REGPARAM;
+static uae_u32 REGPARAM3 uaesndboard_wget(uaecptr) REGPARAM;
+static uae_u32 REGPARAM3 uaesndboard_bget(uaecptr) REGPARAM;
+static void REGPARAM3 uaesndboard_lput(uaecptr, uae_u32) REGPARAM;
+static void REGPARAM3 uaesndboard_wput(uaecptr, uae_u32) REGPARAM;
+static void REGPARAM3 uaesndboard_bput(uaecptr, uae_u32) REGPARAM;
+
+static addrbank uaesndboard_sub_bank_z2 = {
+	uaesndboard_lget, uaesndboard_wget, uaesndboard_bget,
+	uaesndboard_lput, uaesndboard_wput, uaesndboard_bput,
+	default_xlate, default_check, NULL, NULL, _T("uaesnd z2"),
+	dummy_lgeti, dummy_wgeti,
+	ABFLAG_IO, S_READ, S_WRITE
+};
+
+static struct addrbank_sub uaesndz2_sub_banks[] = {
+	{ &uaesndboard_sub_bank_z2, 0x0000 },
+	{ &uaesndboard_ram_bank, 0x8000 },
+	{ NULL }
+};
+
+static addrbank uaesndboard_bank_z3 = {
+	uaesndboard_lget, uaesndboard_wget, uaesndboard_bget,
+	uaesndboard_lput, uaesndboard_wput, uaesndboard_bput,
+	default_xlate, default_check, NULL, NULL, _T("uaesnd z3"),
+	dummy_lgeti, dummy_wgeti,
+	ABFLAG_IO, S_READ, S_WRITE
+};
+
+static addrbank uaesndboard_bank_z2 = {
+	sub_bank_lget, sub_bank_wget, sub_bank_bget,
+	sub_bank_lput, sub_bank_wput, sub_bank_bput,
+	default_xlate, default_check, NULL, NULL, _T("uaesnd z2"),
+	dummy_lgeti, dummy_wgeti,
+	ABFLAG_IO, S_READ, S_WRITE, uaesndz2_sub_banks
+};
+
 static uae_u32 REGPARAM2 uaesndboard_bget(uaecptr addr)
 {
 	uae_u8 v = 0;
@@ -1148,36 +1183,6 @@ static void REGPARAM2 uaesndboard_lput(uaecptr addr, uae_u32 b)
 		}
 	}
 }
-
-static addrbank uaesndboard_sub_bank_z2 = {
-	uaesndboard_lget, uaesndboard_wget, uaesndboard_bget,
-	uaesndboard_lput, uaesndboard_wput, uaesndboard_bput,
-	default_xlate, default_check, NULL, NULL, _T("uaesnd z2"),
-	dummy_lgeti, dummy_wgeti,
-	ABFLAG_IO, S_READ, S_WRITE
-};
-
-static struct addrbank_sub uaesndz2_sub_banks[] = {
-	{ &uaesndboard_sub_bank_z2, 0x0000 },
-	{ &uaesndboard_ram_bank, 0x8000 },
-	{ NULL }
-};
-
-static addrbank uaesndboard_bank_z3 = {
-	uaesndboard_lget, uaesndboard_wget, uaesndboard_bget,
-	uaesndboard_lput, uaesndboard_wput, uaesndboard_bput,
-	default_xlate, default_check, NULL, NULL, _T("uaesnd z3"),
-	dummy_lgeti, dummy_wgeti,
-	ABFLAG_IO, S_READ, S_WRITE
-};
-
-static addrbank uaesndboard_bank_z2 = {
-	sub_bank_lget, sub_bank_wget, sub_bank_bget,
-	sub_bank_lput, sub_bank_wput, sub_bank_bput,
-	default_xlate, default_check, NULL, NULL, _T("uaesnd z2"),
-	dummy_lgeti, dummy_wgeti,
-	ABFLAG_IO, S_READ, S_WRITE, uaesndz2_sub_banks
-};
 
 static void ew(uae_u8 *acmemory, int addr, uae_u32 value)
 {
@@ -1480,8 +1485,6 @@ struct snddev_data {
 };
 
 static struct snddev_data snddev[MAX_SNDDEVS];
-
-extern addrbank toccata_bank;
 
 #define STATUS_ACTIVE 1
 #define STATUS_RESET 2
@@ -2137,6 +2140,21 @@ static struct snddev_data *getsnddev(uaecptr addr)
 	return NULL;
 }
 
+static uae_u32 REGPARAM3 toccata_lget(uaecptr) REGPARAM;
+static uae_u32 REGPARAM3 toccata_wget(uaecptr) REGPARAM;
+static uae_u32 REGPARAM3 toccata_bget(uaecptr) REGPARAM;
+static void REGPARAM3 toccata_lput(uaecptr, uae_u32) REGPARAM;
+static void REGPARAM3 toccata_wput(uaecptr, uae_u32) REGPARAM;
+static void REGPARAM3 toccata_bput(uaecptr, uae_u32) REGPARAM;
+
+static addrbank toccata_bank = {
+	toccata_lget, toccata_wget, toccata_bget,
+	toccata_lput, toccata_wput, toccata_bput,
+	default_xlate, default_check, NULL, _T("*"), _T("Toccata"),
+	dummy_lgeti, dummy_wgeti,
+	ABFLAG_IO, S_READ, S_WRITE
+};
+
 static void REGPARAM2 toccata_bput(uaecptr addr, uae_u32 b)
 {
 	addr &= 0xffffff;
@@ -2212,14 +2230,6 @@ static uae_u32 REGPARAM2 toccata_lget(uaecptr addr)
 	v |= toccata_bget(addr + 3) << 0;
 	return v;
 }
-
-static addrbank toccata_bank = {
-	toccata_lget, toccata_wget, toccata_bget,
-	toccata_lput, toccata_wput, toccata_bput,
-	default_xlate, default_check, NULL, _T("*"), _T("Toccata"),
-	dummy_lgeti, dummy_wgeti,
-	ABFLAG_IO, S_READ, S_WRITE
-};
 
 static addrbank prelude_bank = {
 	toccata_lget, toccata_wget, toccata_bget,

--- a/sndboard.cpp
+++ b/sndboard.cpp
@@ -22,6 +22,9 @@
 #include "qemuvga/qemuaudio.h"
 #include "rommgr.h"
 #include "devices.h"
+#ifndef _WIN32
+#include "sndboard_host.h"
+#endif
 
 #define DEBUG_SNDDEV 0
 #define DEBUG_SNDDEV_READ 0
@@ -2437,6 +2440,8 @@ static struct fm801_data fm801;
 static bool fm801_active;
 static const int fm801_freq[16] = { 5500, 8000, 9600, 11025, 16000, 19200, 22050, 32000, 38400, 44100, 48000 };
 
+#ifdef WITH_PCI
+
 static void calculate_volume_fm801(void)
 {
 	struct fm801_data *data = &fm801;
@@ -2832,6 +2837,8 @@ const struct pci_board solo1_pci_board =
 	}
 };
 
+#endif
+
 static SWVoiceOut *qemu_voice_out;
 
 static bool audio_state_sndboard_qemu(int streamid, void *params)
@@ -3015,8 +3022,10 @@ static void sndboard_vsync(void)
 {
 	if (snddev[0].snddev_active)
 		sndboard_vsync_toccata(&snddev[0]);
+#ifdef WITH_PCI
 	if (fm801_active)
 		sndboard_vsync_fm801();
+#endif
 	if (qemu_voice_out_active())
 		sndboard_vsync_qemu();
 }
@@ -3025,8 +3034,10 @@ void sndboard_ext_volume(void)
 {
 	if (snddev[0].snddev_active)
 		calculate_volume_toccata(&snddev[0]);
+#ifdef WITH_PCI
 	if (fm801_active)
 		calculate_volume_fm801();
+#endif
 	calculate_volume_qemu_all();
 }
 
@@ -3181,6 +3192,28 @@ Exit:;
 	write_log(_T("sndboard capture init failed %08x\n"), hr);
 	sndboard_free_capture();
 	return false;
+}
+
+#else
+
+static uae_u8 *sndboard_get_buffer(int *frames)
+{
+	return unix_sndboard_get_buffer(frames);
+}
+
+static void sndboard_release_buffer(uae_u8 *buffer, int frames)
+{
+	unix_sndboard_release_buffer(buffer, frames);
+}
+
+static void sndboard_free_capture(void)
+{
+	unix_sndboard_free_capture();
+}
+
+static bool sndboard_init_capture(int freq)
+{
+	return unix_sndboard_init_capture(freq);
 }
 
 #endif


### PR DESCRIPTION
  ## Summary

Add host capture hooks for non-Windows sound-board builds and keep sound-board memory-bank objects file-local.

This lets non-Windows builds use the shared sound-board code without pulling in Windows capture code or exporting sound-board `addrbank` objects that are only used inside `sndboard.cpp`.

## Details

  - Include the non-Windows sound-board host backend outside `_WIN32`.
  - Route capture buffer init/free/get/release operations through that backend.
  - Guard FM801 PCI helpers behind `WITH_PCI` so non-PCI builds do not require PCI state.
  - Replace external `addrbank` forward declarations with local callback declarations.
  - Move the static bank objects before the accessors that reference them, keeping the bank symbols file-local.
