### PR TITLE
Fix JIT LINK with A7 fallback

### DIFF
--- a/jit/arm/compemu_arm.cpp
+++ b/jit/arm/compemu_arm.cpp
@@ -11355,6 +11355,11 @@ uae_u32 REGPARAM2 op_4808_0_comp_ff(uae_u32 opcode) {
 	uae_s32 srcreg = (opcode & 7);
 	uae_u32 m68k_pc_offset_thisinst = m68k_pc_offset;
 	m68k_pc_offset += 2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	int dodgy = 0;
 	if (srcreg == 7) dodgy = 1;
 	int src = dodgy ? alloc_scratch() : srcreg + 8;
@@ -13964,6 +13969,11 @@ uae_u32 REGPARAM2 op_4e50_0_comp_ff(uae_u32 opcode) {
 	uae_s32 srcreg = (opcode & 7);
 	uae_u32 m68k_pc_offset_thisinst = m68k_pc_offset;
 	m68k_pc_offset += 2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	int dodgy = 0;
 	if (srcreg == 7) dodgy = 1;
 	int src = dodgy ? alloc_scratch() : srcreg + 8;
@@ -38554,6 +38564,11 @@ uae_u32 REGPARAM2 op_4808_0_comp_nf(uae_u32 opcode) {
 	uae_s32 srcreg = (opcode & 7);
 	uae_u32 m68k_pc_offset_thisinst = m68k_pc_offset;
 	m68k_pc_offset += 2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	int dodgy = 0;
 	if (srcreg == 7) dodgy = 1;
 	int src = dodgy ? alloc_scratch() : srcreg + 8;
@@ -41066,6 +41081,11 @@ uae_u32 REGPARAM2 op_4e50_0_comp_nf(uae_u32 opcode) {
 	uae_s32 srcreg = (opcode & 7);
 	uae_u32 m68k_pc_offset_thisinst = m68k_pc_offset;
 	m68k_pc_offset += 2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	int dodgy = 0;
 	if (srcreg == 7) dodgy = 1;
 	int src = dodgy ? alloc_scratch() : srcreg + 8;

--- a/jit/compemu.cpp
+++ b/jit/compemu.cpp
@@ -24929,6 +24929,11 @@ uae_u32 REGPARAM2 op_4808_0_comp_ff(uae_u32 opcode) /* LINK */
 	uae_u32 dodgy=0;
 	uae_u32 m68k_pc_offset_thisinst=m68k_pc_offset;
 	m68k_pc_offset+=2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	{
 		uae_u8 scratchie=S1;
 		{
@@ -27698,6 +27703,11 @@ uae_u32 REGPARAM2 op_4e50_0_comp_ff(uae_u32 opcode) /* LINK */
 	uae_u32 dodgy=0;
 	uae_u32 m68k_pc_offset_thisinst=m68k_pc_offset;
 	m68k_pc_offset+=2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	{
 		uae_u8 scratchie=S1;
 		{
@@ -76044,6 +76054,11 @@ uae_u32 REGPARAM2 op_4808_0_comp_nf(uae_u32 opcode) /* LINK */
 	uae_u32 dodgy=0;
 	uae_u32 m68k_pc_offset_thisinst=m68k_pc_offset;
 	m68k_pc_offset+=2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	{
 		uae_u8 scratchie=S1;
 		{
@@ -78951,6 +78966,11 @@ uae_u32 REGPARAM2 op_4e50_0_comp_nf(uae_u32 opcode) /* LINK */
 	uae_u32 dodgy=0;
 	uae_u32 m68k_pc_offset_thisinst=m68k_pc_offset;
 	m68k_pc_offset+=2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	{
 		uae_u8 scratchie=S1;
 		{

--- a/jit/gencomp.cpp
+++ b/jit/gencomp.cpp
@@ -1971,6 +1971,11 @@ gen_opcode(unsigned int opcode)
 #ifdef DISABLE_I_LINK
 		failure;
 #endif
+		comprintf("\tif (srcreg == 7) {\n"
+			"\t\tm68k_pc_offset = m68k_pc_offset_thisinst;\n"
+			"\t\tFAIL(1);\n"
+			"\t\t" RETURN "\n"
+			"\t}\n");
 		genamode(curi->smode, "srcreg", sz_long, "src", GENA_GETV_FETCH, GENA_MOVEM_DO_INC);
 		genamode(curi->dmode, "dstreg", curi->size, "offs", GENA_GETV_FETCH, GENA_MOVEM_DO_INC);
 		comprintf("\tsub_l_ri(SP_REG,4);\n"

--- a/jit/gencomp_arm.c
+++ b/jit/gencomp_arm.c
@@ -4204,6 +4204,11 @@ gen_opcode(unsigned long int opcode) {
 		break;
 
 	case i_LINK:
+		comprintf("\tif (srcreg == 7) {\n"
+				"\t\tm68k_pc_offset = m68k_pc_offset_thisinst;\n"
+				"\t\tFAIL(1);\n"
+				"\t\treturn;\n"
+				"\t}\n");
 		genamode(curi->smode, "srcreg", sz_long, "src", 1, 0);
 		genamode(curi->dmode, "dstreg", curi->size, "offs", 1, 0);
 		comprintf("\tsub_l_ri(15,4);\n"


### PR DESCRIPTION
## Summary
- Force JIT interpreter fallback for `LINK.W/L An,#imm` when `An == A7`.
- Apply the fallback in both generated JIT outputs: `jit/compemu.cpp` and `jit/arm/compemu_arm.cpp`.
- Update the corresponding generators: `jit/gencomp.cpp` and `jit/gencomp_arm.c`.

## Why
`LINK.x #imm,SP` aliases the frame register with the stack pointer. The generated JIT paths can clobber or preserve the wrong SP value around the predecrement/push and final SP adjustment. This operand combination is not useful for normal software, but CPU tests can use it for detection. Falling back to the interpreter matches the existing conservative handling style for awkward JIT operand aliases.

## Validation
- `git diff --check`
- Structural check confirmed all 4 `LINK.W/L` handlers in `jit/compemu.cpp` contain the A7 fallback.
- Structural check confirmed all 4 `LINK.W/L` handlers in `jit/arm/compemu_arm.cpp` contain the A7 fallback.
- Verified the equivalent Amiberry ARM64 change with cputester under JIT: `basic/link.w`, `basic/link.l`, `basic/bcc.b`, `basic/bcc.w`, `basic/bsr.b`.
