### PR TITLE
Fix ARM JIT branch target PC state

### DIFF
--- a/jit/arm/codegen_arm.cpp
+++ b/jit/arm/codegen_arm.cpp
@@ -234,11 +234,26 @@ LOWFUNC(WRITE,READ,1,compemu_raw_cmp_pc,(IMPTR s))
 }
 LENDFUNC(WRITE,READ,1,compemu_raw_cmp_pc,(IMPTR s))
 
+STATIC_INLINE void compemu_raw_store_pc_state_from_work1(void)
+{
+  uintptr idx = (uintptr)&regs.pc_p - (uintptr)&regs;
+  STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
+  idx = (uintptr)&regs.pc_oldp - (uintptr)&regs;
+  STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
+
+#ifdef NATMEM_OFFSET
+  SUB_rrr(REG_WORK2, REG_WORK1, R_MEMSTART);
+  idx = (uintptr)&regs.pc - (uintptr)&regs;
+  STR_rRI(REG_WORK2, R_REGSTRUCT, idx);
+  idx = (uintptr)&regs.instruction_pc - (uintptr)&regs;
+  STR_rRI(REG_WORK2, R_REGSTRUCT, idx);
+#endif
+}
+
 LOWFUNC(NONE,WRITE,1,compemu_raw_set_pc_i,(IMPTR s))
 {
-  LOAD_U32(REG_WORK2, s);
-  uintptr idx = (uintptr) &(regs.pc_p) - (uintptr) &regs;
-  STR_rRI(REG_WORK2, R_REGSTRUCT, idx);
+  LOAD_U32(REG_WORK1, s);
+  compemu_raw_store_pc_state_from_work1();
 }
 LENDFUNC(NONE,WRITE,1,compemu_raw_set_pc_i,(IMPTR s))
 

--- a/jit/arm/codegen_arm64.cpp
+++ b/jit/arm/codegen_arm64.cpp
@@ -241,11 +241,26 @@ LOWFUNC(WRITE,READ,1,compemu_raw_cmp_pc,(IMPTR s))
 }
 LENDFUNC(WRITE,READ,1,compemu_raw_cmp_pc,(IMPTR s))
 
+STATIC_INLINE void compemu_raw_store_pc_state_from_work1(void)
+{
+	uintptr idx = (uintptr)&regs.pc_p - (uintptr)&regs;
+	STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
+	idx = (uintptr)&regs.pc_oldp - (uintptr)&regs;
+	STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
+
+#ifdef NATMEM_OFFSET
+	SUB_xxx(REG_WORK2, REG_WORK1, R_MEMSTART);
+	idx = (uintptr)&regs.pc - (uintptr)&regs;
+	STR_wXi(REG_WORK2, R_REGSTRUCT, idx);
+	idx = (uintptr)&regs.instruction_pc - (uintptr)&regs;
+	STR_wXi(REG_WORK2, R_REGSTRUCT, idx);
+#endif
+}
+
 LOWFUNC(NONE,WRITE,1,compemu_raw_set_pc_i,(IMPTR s))
 {
 	LOAD_U64(REG_WORK1, s);
-	uintptr idx = (uintptr) &(regs.pc_p) - (uintptr) &regs;
-	STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
+	compemu_raw_store_pc_state_from_work1();
 }
 LENDFUNC(NONE,WRITE,1,compemu_raw_set_pc_i,(IMPTR s))
 

--- a/jit/arm/compemu_support_arm.cpp
+++ b/jit/arm/compemu_support_arm.cpp
@@ -3476,32 +3476,19 @@ STATIC_INLINE void create_popalls(void)
 
     /* now the exit points */
     popall_execute_normal_setpc = get_target();
-    uintptr idx = (uintptr) & (regs.pc_p) - (uintptr)&regs;
-#if defined(CPU_AARCH64)
-    STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
-#else
-    STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
-#endif
+    compemu_raw_store_pc_state_from_work1();
     popall_execute_normal = get_target();
     raw_pop_preserved_regs();
     compemu_raw_jmp((uintptr)execute_normal);
 
     popall_check_checksum_setpc = get_target();
-#if defined(CPU_AARCH64)
-    STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
-#else
-    STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
-#endif
+    compemu_raw_store_pc_state_from_work1();
     popall_check_checksum = get_target();
     raw_pop_preserved_regs();
     compemu_raw_jmp((uintptr)check_checksum);
 
     popall_exec_nostats_setpc = get_target();
-#if defined(CPU_AARCH64)
-    STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
-#else
-    STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
-#endif
+    compemu_raw_store_pc_state_from_work1();
     raw_pop_preserved_regs();
     compemu_raw_jmp((uintptr)exec_nostats);
 


### PR DESCRIPTION
## Summary
- Keep the ARM/ARM64 JIT direct PC tuple coherent when set-PC paths leave compiled code: `regs.pc_p`, `regs.pc_oldp`, `regs.pc`, and `regs.instruction_pc` are updated together.
- Use the same PC-state emitter for the branch-to-block set-PC popall stubs, deriving the M68K PC from `pc_p - natmem_offset`.
- Carries the Amiberry branch-target fix for Toni's cputester illegal-instruction target case. The `LINK.W/L An==A7` fallback from this work was already merged separately in #457.

## Validation
- `git diff --check origin/master..HEAD`
- Structural helper check: `helpers=2 calls=5` across `jit/arm/codegen_arm64.cpp`, `jit/arm/codegen_arm.cpp`, and `jit/arm/compemu_support_arm.cpp`.
