### PR TITLE
Fix UAESND stream volume handling

### DIFF
--- a/sndboard.cpp
+++ b/sndboard.cpp
@@ -562,6 +562,11 @@ static bool uaesnd_directload(struct uaesndboard_data *data, struct uaesndboard_
 	if (reg < 0 || reg == 20) {
 		s->replen = get_long_host(s->io + 20);
 	}
+	if (reg < 0 || reg == 24 || reg == 26) {
+		// repeat count + volume share a long word; reload volume so
+		// current-set volume writes take effect while playing
+		s->volume = get_word_host(s->io + 26);
+	}
 	return uaesnd_validate(data, s);
 }
 
@@ -686,7 +691,9 @@ static bool audio_state_sndboard_uae(int streamid, void *params)
 				if (sign)
 					sample -= 0x8000;
 				uae_s16 samples = (uae_s16)sample;
-				s->sample[i] = samples * ((s->volume + 1) / 2 + (data->volume[i] + 1) / 2) / 32768;
+				// scale by set volume and board channel volume multiplicatively
+				// so volume 0 is silent (the old averaged formula had a 0.5 gain floor)
+				s->sample[i] = samples * s->volume / 32768 * data->volume[i] / 32768;
 			}
 			if (len < 0)
 				addr -= s->framesize;
@@ -1213,8 +1220,9 @@ bool uaesndboard_init (struct autoconfig_info *aci, int z)
 	if (!ert)
 		return false;
 	data->streammask = 0;
-	data->volume[0] = 32768;
-	data->volume[1] = 32768;
+	for (int i = 0; i < MAX_UAE_CHANNELS; i++) {
+		data->volume[i] = 32768;
+	}
 	put_long_host(data->info + 0, (UAEMAJOR << 16) | (UAEMINOR << 8) | (UAESUBREV));
 	put_long_host(data->info + 4, (1 << 16) | (0));
 	put_long_host(data->info + 8, currprefs.sound_freq);


### PR DESCRIPTION
While developing an AHI driver for the UAESND sound board (for Amiberry, which shares this emulation code), two volume-handling issues surfaced in uaesnd:

1. **Volume register writes are ignored during playback.** `s->volume` is only read from the sample set structure when a set is (re)loaded; `uaesnd_directload()` never reloads it on writes to the current-set registers, although the spec comment says current-set writes are "nearly immediate, values are updated during next sample period". As a result, any volume change on a playing/looping stream (e.g. an AHI volume fade on a repeating sound) does nothing until the set chains to the next one.

2. **The volume formula has a 0.5 gain floor.** `samples * ((s->volume + 1) / 2 + (data->volume[i] + 1) / 2) / 32768` averages the set volume with the board channel volume, so volume 0 still plays at half loudness. This PR makes the scaling multiplicative: volume 0 is silent, full volume is unchanged. Board channel volumes are also initialized for all stream channels instead of only the first two, so 5.1/7.1 stream channels are no longer attenuated relative to the front pair.

The same fix has been applied to Amiberry: BlitterStudio/amiberry#2092