### PR TITLE
Handle CCK counter wrap in cycle deltas

### DIFF
--- a/include/events.h
+++ b/include/events.h
@@ -122,9 +122,10 @@ STATIC_INLINE evt_t get_cck_cycles(void)
 }
 STATIC_INLINE uae_s32 get_cck_cycles_sub(evt_t cck1, evt_t cck2)
 {
-	assert(cck1 - cck2 < 0x10000000);
-	assert(cck1 - cck2 > -0x10000000);
-	return (uae_s32)(cck1 - cck2);
+	const uae_s32 diff = (uae_s32)((uae_u32)cck1 - (uae_u32)cck2);
+	assert(diff < 0x10000000);
+	assert(diff > -0x10000000);
+	return diff;
 }
 STATIC_INLINE uae_s32 get_cck_cycles_diff(evt_t cck)
 {


### PR DESCRIPTION
currcycle_cck is a 32-bit counter, but get_cck_cycles_sub() was subtracting promoted evt_t values before applying its sanity checks. After currcycle_cck wraps, a normal small modulo delta can look like a very large negative signed delta and trip the assertion.

Compute the delta in the same 32-bit modulo domain first, then keep the existing sanity range assertions on the signed result.

This fixed a reproducible Amiberry crash reported in BlitterStudio/amiberry#2098, where Linux assertion-enabled builds aborted after longer RTG/P96 sessions with:

```
get_cck_cycles_sub(): Assertion `cck1 - cck2 > -0x10000000` failed
```

The same helper and currcycle_cck type are present here, so the core timing fix applies directly.