### PR TITLE
filesys: handle OS4 examinedata fallback packets

### DIFF
--- a/filesys.cpp
+++ b/filesys.cpp
@@ -359,6 +359,10 @@ static struct uaedev_mount_info mountinfo;
 
 /* OS4 64-bit filesize packets */
 #define ACTION_FILESYSTEM_ATTR         3005
+#define ACTION_EXAMINEDATA             3030
+#define ACTION_EXAMINEDATA_FH          3031
+#define ACTION_EXAMINEDATA_OBJ         3032
+#define ACTION_EXAMINEDATA_DIR         3040
 #define ACTION_CHANGE_FILE_POSITION64  8001
 #define ACTION_GET_FILE_POSITION64     8002
 #define ACTION_CHANGE_FILE_SIZE64      8003
@@ -7107,6 +7111,13 @@ static int handle_packet(TrapContext *ctx, Unit *unit, dpacket *pck, uae_u32 msg
 	case ACTION_GET_FILE_POSITION64: action_get_file_position64 (ctx, unit, pck); break;
 	case ACTION_CHANGE_FILE_SIZE64: action_change_file_size64 (ctx, unit, pck); break;
 	case ACTION_GET_FILE_SIZE64: action_get_file_size64 (ctx, unit, pck); break;
+	case ACTION_EXAMINEDATA:
+	case ACTION_EXAMINEDATA_FH:
+	case ACTION_EXAMINEDATA_OBJ:
+	case ACTION_EXAMINEDATA_DIR:
+		PUT_PCK_RES1(pck, DOS_FALSE);
+		PUT_PCK_RES2(pck, ERROR_ACTION_NOT_KNOWN);
+		break;
 
 		/* MOS packet types */
 	case ACTION_SEEK64: action_seek64(ctx, unit, pck); break;


### PR DESCRIPTION
AmigaOS 4 may probe ACTION_EXAMINEDATA, ACTION_EXAMINEDATA_FH, ACTION_EXAMINEDATA_OBJ, and ACTION_EXAMINEDATA_DIR on directory filesystem handlers.

These packets can validly return FALSE/ERROR_ACTION_NOT_KNOWN so dos.library falls back to legacy examine emulation. Treat them as known unsupported packets instead of logging them as unknown.\n\nObserved while booting AmigaOS 4 ClassicInstallCD, where bd6/bd7 packet probes repeatedly hit the generic unknown-packet log path.