### PR TITLE
Networking Fixes

### DIFF
--- a/a2065.cpp
+++ b/a2065.cpp
@@ -430,6 +430,11 @@ static void gotfunc2(void *devv, const uae_u8 *databuf, int len)
 
 	// winpcap does not include checksum bytes
 	if (!(csr[4] & 0x0400)) { // ASTRP_RCV
+		if (len > MAX_PACKET_SIZE - 4) {
+			if (log_a2065)
+				write_log (_T("7990: oversize frame with FCS, %d bytes\n"), len);
+			return;
+		}
 		crc32 = get_crc32 (d, len);
 		d[len++] = crc32 >> 24;
 		d[len++] = crc32 >> 16;
@@ -526,15 +531,41 @@ static bool receive_queue_pop(uae_u8 *data, int *len)
 	return got;
 }
 
-static bool receive_space_available(int len)
+static int receive_packet_buffer_size(int len)
 {
-	int needed;
-
-	if (!am_initialized || !(csr[0] & CSR0_RXON) || !am_rdr_rlen)
-		return false;
-	needed = len < 60 ? 60 : len;
+	if (len <= 0 || len > MAX_PACKET_SIZE)
+		return -1;
+	if (!(csr[4] & 0x0400) && len > MAX_PACKET_SIZE - 4) /* ASTRP_RCV */
+		return -1;
+	int needed = len < 60 ? 60 : len;
 	if (!(csr[4] & 0x0400)) /* ASTRP_RCV */
 		needed += 4;
+	return needed;
+}
+
+static bool receive_packet_can_fit(int len)
+{
+	int needed = receive_packet_buffer_size(len);
+
+	if (needed < 0 || !am_initialized || !am_rdr_rlen)
+		return false;
+	for (int i = 0; i < am_rdr_rlen; i++) {
+		const int offset = (rdr_offset + i) % am_rdr_rlen;
+		const uae_u32 off = am_rdr_rdra + offset * 8;
+		const uae_u16 rmd2 = get_ram_word(off + 4);
+		needed -= 65536 - rmd2;
+		if (needed <= 0)
+			return true;
+	}
+	return false;
+}
+
+static bool receive_space_available(int len)
+{
+	int needed = receive_packet_buffer_size(len);
+
+	if (needed < 0 || !am_initialized || !(csr[0] & CSR0_RXON) || !am_rdr_rlen)
+		return false;
 	for (int i = 0; i < am_rdr_rlen; i++) {
 		const int offset = (rdr_offset + i) % am_rdr_rlen;
 		const uae_u32 off = am_rdr_rdra + offset * 8;
@@ -557,6 +588,13 @@ static void receive_queue_drain(void)
 		int len = receive_queue_peek_size();
 		if (len <= 0)
 			return;
+		if (!receive_packet_can_fit(len)) {
+			if (!receive_queue_pop(packet, &len))
+				return;
+			if (log_a2065)
+				write_log(_T("7990: dropping frame that does not fit receive ring, %d bytes\n"), len);
+			continue;
+		}
 		if (!receive_space_available(len))
 			return;
 		if (!receive_queue_pop(packet, &len))

--- a/slirp/bootp.cpp
+++ b/slirp/bootp.cpp
@@ -125,7 +125,6 @@ static void bootp_reply(struct bootp_t *bp)
     struct mbuf *m;
     struct bootp_t *rbp;
     struct sockaddr_in saddr, daddr;
-    struct in_addr dns_addr;
     int dhcp_msg_type, val;
     uint8_t *q;
 
@@ -216,11 +215,14 @@ have_addr:
         memcpy(q, &saddr.sin_addr, 4);
         q += 4;
         
-        *q++ = RFC1533_DNS;
-        *q++ = 4;
-        dns_addr.s_addr = htonl(ntohl(special_addr.s_addr) | CTL_DNS);
-        memcpy(q, &dns_addr, 4);
-        q += 4;
+        if (dns_addr_valid) {
+            struct in_addr guest_dns_addr;
+            *q++ = RFC1533_DNS;
+            *q++ = 4;
+            guest_dns_addr.s_addr = htonl(ntohl(special_addr.s_addr) | CTL_DNS);
+            memcpy(q, &guest_dns_addr, 4);
+            q += 4;
+        }
 
         *q++ = RFC2132_LEASE_TIME;
         *q++ = 4;

--- a/slirp/ip_icmp.cpp
+++ b/slirp/ip_icmp.cpp
@@ -200,6 +200,11 @@ void icmp_input(struct mbuf *m, int hlen)
 	/* It's an alias */
 	switch(ntohl(so->so_faddr.s_addr) & 0xff) {
 	case CTL_DNS:
+	  if (!dns_addr_valid) {
+	    icmp_error(m, ICMP_UNREACH, ICMP_UNREACH_NET, 0, "DNS disabled");
+	    udp_detach(so);
+	    goto end_error;
+	  }
 	  addr.sin_addr = dns_addr;
 	  break;
 	case CTL_ALIAS:

--- a/slirp/main.h
+++ b/slirp/main.h
@@ -38,6 +38,7 @@ extern struct in_addr alias_addr;
 extern struct in_addr our_addr;
 extern struct in_addr loopback_addr;
 extern struct in_addr dns_addr;
+extern int dns_addr_valid;
 extern char *username;
 extern char *socket_path;
 extern int towrite_max;

--- a/slirp/slirp.cpp
+++ b/slirp/slirp.cpp
@@ -5,6 +5,7 @@
 struct in_addr our_addr;
 /* host dns address */
 struct in_addr dns_addr;
+int dns_addr_valid;
 /* host loopback address */
 struct in_addr loopback_addr;
 
@@ -32,7 +33,7 @@ char slirp_hostname[33];
 
 #ifdef _WIN32
 
-static int get_dns_addr(struct in_addr *pdns_addr)
+static bool get_dns_addr(struct in_addr *pdns_addr)
 {
     FIXED_INFO *FixedInfo=NULL;
     ULONG    BufLen;
@@ -57,11 +58,17 @@ static int get_dns_addr(struct in_addr *pdns_addr)
             GlobalFree(FixedInfo);
             FixedInfo = NULL;
         }
-        return -1;
+        return false;
     }
      
     pIPAddr = &(FixedInfo->DnsServerList);
-    inet_aton(pIPAddr->IpAddress.String, &tmp_addr);
+    if (!inet_aton(pIPAddr->IpAddress.String, &tmp_addr)) {
+        if (FixedInfo) {
+            GlobalFree(FixedInfo);
+            FixedInfo = NULL;
+        }
+        return false;
+    }
     *pdns_addr = tmp_addr;
 #if 0
     printf( "DNS Servers:\n" );
@@ -77,46 +84,68 @@ static int get_dns_addr(struct in_addr *pdns_addr)
         GlobalFree(FixedInfo);
         FixedInfo = NULL;
     }
-    return 0;
+    return true;
 }
 
 #else
 
-static int get_dns_addr(struct in_addr *pdns_addr)
+static bool record_dns_server(const char *server, struct in_addr *pdns_addr,
+    int *found4, int *found6)
+{
+    struct in_addr tmp_addr;
+
+    if (!inet_aton(server, &tmp_addr)) {
+#ifdef AF_INET6
+        struct in6_addr tmp_addr6;
+        if (inet_pton(AF_INET6, server, &tmp_addr6) == 1)
+            (*found6)++;
+#endif
+        return false;
+    }
+
+    if (!*found4)
+        *pdns_addr = tmp_addr;
+    else
+        lprint(", ");
+    if (++*found4 > 3) {
+        lprint("(more)");
+        return true;
+    }
+    lprint("%s", inet_ntoa(tmp_addr));
+    return false;
+}
+
+static bool get_dns_addr(struct in_addr *pdns_addr)
 {
     char buff[512];
     char buff2[256+1];
     FILE *f;
-    int found = 0;
-    struct in_addr tmp_addr;
-    
+    int found4 = 0;
+    int found6 = 0;
+
     f = fopen("/etc/resolv.conf", "r");
-    if (!f)
-        return -1;
+    if (!f) {
+        write_log("SLIRP: no resolver configuration found, DNS disabled\n");
+        return false;
+    }
 
     lprint("IP address of your DNS(s): ");
     while (fgets(buff, 512, f) != NULL) {
         if (sscanf(buff, "nameserver%*[ \t]%256s", buff2) == 1) {
-            if (!inet_aton(buff2, &tmp_addr))
-                continue;
-            if (tmp_addr.s_addr == loopback_addr.s_addr)
-                tmp_addr = our_addr;
-            /* If it's the first one, set it to dns_addr */
-            if (!found)
-                *pdns_addr = tmp_addr;
-            else
-                lprint(", ");
-            if (++found > 3) {
-                lprint("(more)");
+            if (record_dns_server(buff2, pdns_addr, &found4, &found6))
                 break;
-            } else
-                lprint("%s", inet_ntoa(tmp_addr));
         }
     }
     fclose(f);
-    if (!found)
-        return -1;
-    return 0;
+    if (!found4) {
+        if (found6) {
+            write_log("SLIRP: only IPv6 DNS servers found, DNS forwarding disabled\n");
+        } else {
+            write_log("SLIRP: no IPv4 DNS server found, DNS forwarding disabled\n");
+        }
+        return false;
+    }
+    return true;
 }
 
 #endif
@@ -147,8 +176,7 @@ int slirp_init(void)
     /* set default addresses */
     inet_aton("127.0.0.1", &loopback_addr);
 
-    if (get_dns_addr(&dns_addr) < 0)
-        return -1;
+    dns_addr_valid = get_dns_addr(&dns_addr);
 
     inet_aton(CTL_SPECIAL, &special_addr);
 	alias_addr.s_addr = special_addr.s_addr | htonl(CTL_ALIAS);
@@ -611,7 +639,7 @@ void arp_input(const uint8_t *pkt, int pkt_len)
     switch(ar_op) {
     case ARPOP_REQUEST:
         if (!memcmp(ah->ar_tip, &special_addr, 3)) {
-            if (ah->ar_tip[3] == CTL_DNS || ah->ar_tip[3] == CTL_ALIAS) 
+            if ((ah->ar_tip[3] == CTL_DNS && dns_addr_valid) || ah->ar_tip[3] == CTL_ALIAS)
                 goto arp_ok;
             for (ex_ptr = exec_list; ex_ptr; ex_ptr = ex_ptr->ex_next) {
                 if (ex_ptr->ex_addr == ah->ar_tip[3])

--- a/slirp/socket.cpp
+++ b/slirp/socket.cpp
@@ -498,6 +498,8 @@ int sosendto(struct socket *so, struct mbuf *m)
 	  /* It's an alias */
 	  switch(ntohl(so->so_faddr.s_addr) & 0xff) {
 	  case CTL_DNS:
+	    if (!dns_addr_valid)
+	      return -1;
 	    addr.sin_addr = dns_addr;
 	    break;
 	  case CTL_ALIAS:

--- a/slirp/tcp_subr.cpp
+++ b/slirp/tcp_subr.cpp
@@ -403,6 +403,11 @@ int tcp_fconnect(struct socket *so)
       /* It's an alias */
       switch(ntohl(so->so_faddr.s_addr) & 0xff) {
       case CTL_DNS:
+	if (!dns_addr_valid) {
+	  closesocket(s);
+	  so->s = -1;
+	  return 0;
+	}
 	addr.sin_addr = dns_addr;
 	break;
       case CTL_ALIAS:


### PR DESCRIPTION
## Summary

Two independent networking fixes in shared code:

- **A2065**: the receive queue could stall forever if the packet at
  its head was larger than the current descriptor ring could accept.
  Check the full frame size, including padding and FCS bytes, before
  draining the queue; drop packets that can never fit, and reject
  packets that would overflow the temporary frame buffer when the
  emulated FCS is appended.
- **SLIRP**: reset transient state when the backend restarts, and only
  advertise a DHCP DNS server when a host resolver is actually
  available. A host loopback resolver in `/etc/resolv.conf` is kept
  as-is instead of being rewritten to the virtual host address ... the
  guest still talks through the SLIRP DNS proxy, but the proxy now
  queries the resolver the host actually has configured. Previously, a
  host with no usable resolver (missing `/etc/resolv.conf`, or a
  failed resolver query on Windows) made `slirp_init()` fail outright
  and the whole virtual network interface never came up; now it comes
  up without DNS forwarding instead.