### PR TITLE
scsi: fix queued DMA and WD33C93 registers

### DIFF
--- a/a2091.cpp
+++ b/a2091.cpp
@@ -1601,9 +1601,18 @@ static void scsi_hsync(void)
 
 static int writeonlyreg (int reg)
 {
-	if (reg == WD_SCSI_STATUS)
+	if (reg == WD_SCSI_STATUS || reg == WD_AUXILIARY_STATUS)
 		return 1;
 	return 0;
+}
+
+static bool invalidreg (struct wd_chip_state *wd, int reg)
+{
+	// Registers after queue tag and before auxiliary status are undriven.
+	if (reg > WD_QUEUE_TAG && reg < WD_AUXILIARY_STATUS)
+		return true;
+	// queue tag is B revision only
+	return reg == WD_QUEUE_TAG && wd->wd33c93_ver < 2;
 }
 
 static void writewdreg (struct wd_chip_state *wd, int sasr, uae_u8 val)
@@ -1617,10 +1626,7 @@ static void writewdreg (struct wd_chip_state *wd, int sasr, uae_u8 val)
 			val &= ~0x20;
 		break;
 	}
-	if (sasr > WD_QUEUE_TAG && sasr < WD_AUXILIARY_STATUS)
-		return;
-	// queue tag is B revision only
-	if (sasr == WD_QUEUE_TAG && wd->wd33c93_ver < 2)
+	if (invalidreg(wd, sasr))
 		return;
 	wd->wdregs[sasr] = val;
 }
@@ -1697,7 +1703,7 @@ uae_u8 wdscsi_get (struct wd_chip_state *wd, struct wd_state *wds)
 	uae_u8 osasr = wd->sasr;
 #endif
 
-	v = wd->wdregs[wd->sasr];
+	v = invalidreg(wd, wd->sasr) ? 0xff : wd->wdregs[wd->sasr];
 	if (wd->sasr == WD_DATA) {
 		if (!wd->wd_data_avail) {
 			write_log (_T("%s WD_DATA READ without data request!? %08x\n"), WD33C93, M68K_GETPC);

--- a/qemuvga/lsi53c710.cpp
+++ b/qemuvga/lsi53c710.cpp
@@ -520,8 +520,7 @@ static void lsi_do_dma(LSIState710 *s, int out)
     dma_addr_t addr;
     SCSIDevice *dev;
 
-    assert(s->current);
-    if (!s->current->dma_len) {
+    if (!s->current || !s->current->dma_len) {
         /* Wait until data is available.  */
         DPRINTF("DMA no data available\n");
         return;

--- a/qemuvga/lsi53c895a.cpp
+++ b/qemuvga/lsi53c895a.cpp
@@ -547,8 +547,7 @@ static void lsi_do_dma(LSIState *s, int out)
     dma_addr_t addr;
     SCSIDevice *dev;
 
-    assert(s->current);
-    if (!s->current->dma_len) {
+    if (!s->current || !s->current->dma_len) {
         /* Wait until data is available.  */
         DPRINTF("DMA no data available\n");
         return;


### PR DESCRIPTION
## Summary

- Wait when 53C710/53C895A DMA starts before a current SCSI request or its data is available, instead of asserting and dereferencing a null request.
- Return `$ff` for undriven WD33C93 registers and keep the auxiliary-status register read-only.

## Background

Both fixes are already merged and tested downstream in Amiberry:

- Queued DMA fix: https://github.com/BlitterStudio/amiberry/commit/acae3c5023897e6674c71c6e5aa1b573c80a9cf8
- WD33C93 fix: https://github.com/BlitterStudio/amiberry/pull/2182
- Original SDMAC report and diagnostic output: https://github.com/BlitterStudio/amiberry/issues/2180

Toni’s hardware-tested SDMAC address-space fix is included through the updated WinUAE master base commit `8b874c33dec0d7b90a9116453d52dde0e2bf239d`.

## Validation

- Built the `winuae_unix` target successfully on macOS with AppleClang 21.
- `git diff --check origin/master...HEAD`
