### PR TITLE
scsi: handle SDMAC access edge cases

### DIFF
--- a/a2091.cpp
+++ b/a2091.cpp
@@ -3605,12 +3605,22 @@ static const addrbank gvp_bank = {
 
 /* SUPERDMAC (A3000 mainboard built-in) */
 
+static uae_u32 mbdmac_reg_address (uae_u32 addr)
+{
+	return addr & (is_dsp_installed ? 0xff : 0x7f);
+}
+
+static bool mbdmac_unmapped_access (uaecptr addr, int size)
+{
+	return (addr & 0xffff) + (1 << size) > 0x4000;
+}
+
 static void mbdmac_write_word (struct wd_state *wd, uae_u32 addr, uae_u32 val)
 {
 #if A3000_DEBUG_IO > 1
 	write_log (_T("DMAC_WWRITE %08X=%04X PC=%08X\n"), addr, val & 0xffff, M68K_GETPC);
 #endif
-	addr &= is_dsp_installed ? 0xfe : 0x7e;
+	addr = mbdmac_reg_address(addr) & 0xfe;
 	switch (addr)
 	{
 	case 0x02:
@@ -3681,7 +3691,7 @@ static void mbdmac_write_byte (struct wd_state *wd, uae_u32 addr, uae_u32 val)
 #if A3000_DEBUG_IO > 1
 	write_log (_T("DMAC_BWRITE %08X=%02X PC=%08X\n"), addr, val & 0xff, M68K_GETPC);
 #endif
-	addr &= is_dsp_installed ? 0xff : 0x7f;
+	addr = mbdmac_reg_address(addr);
 	switch (addr)
 	{
 
@@ -3716,7 +3726,7 @@ static uae_u32 mbdmac_read_word (struct wd_state *wd, uae_u32 addr)
 #endif
 	uae_u32 v = 0xffffffff;
 
-	addr &= is_dsp_installed ? 0xfe : 0x7e;
+	addr = mbdmac_reg_address(addr) & 0xfe;
 	switch (addr)
 	{
 	case 0x02:
@@ -3799,7 +3809,7 @@ static uae_u32 mbdmac_read_byte (struct wd_state *wd, uae_u32 addr)
 #endif
 	uae_u32 v = 0xffffffff;
 
-	addr &= is_dsp_installed ? 0xff : 0x7f;
+	addr = mbdmac_reg_address(addr);
 	switch (addr)
 	{
 	case 0x41:
@@ -3841,7 +3851,7 @@ static void REGPARAM3 mbdmac_bput (uaecptr, uae_u32) REGPARAM;
 static uae_u32 REGPARAM2 mbdmac_lget (uaecptr addr)
 {
 	uae_u32 v;
-	if (addr & 0xc000) { // >= 0xdd4000
+	if (mbdmac_unmapped_access(addr, sz_long)) {
 		v = dummy_get(addr, sz_long, false, 0);
 	} else {
 		v =  mbdmac_read_word (wd_a3000, addr + 0) << 16;
@@ -3852,7 +3862,7 @@ static uae_u32 REGPARAM2 mbdmac_lget (uaecptr addr)
 static uae_u32 REGPARAM2 mbdmac_wget (uaecptr addr)
 {
 	uae_u32 v;
-	if (addr & 0xc000) {
+	if (mbdmac_unmapped_access(addr, sz_word)) {
 		v = dummy_get(addr, sz_word, false, 0);
 	} else {
 		v =  mbdmac_read_word (wd_a3000, addr);
@@ -3862,7 +3872,7 @@ static uae_u32 REGPARAM2 mbdmac_wget (uaecptr addr)
 static uae_u32 REGPARAM2 mbdmac_bget (uaecptr addr)
 {
 	uae_u32 v;
-	if (addr & 0xc000) {
+	if (mbdmac_unmapped_access(addr, sz_byte)) {
 		v = dummy_get(addr, sz_byte, false, 0);
 	} else {
 		v = mbdmac_read_byte (wd_a3000, addr);
@@ -3871,10 +3881,10 @@ static uae_u32 REGPARAM2 mbdmac_bget (uaecptr addr)
 }
 static void REGPARAM2 mbdmac_lput (uaecptr addr, uae_u32 l)
 {
-	if (addr & 0xc000) {
+	if (mbdmac_unmapped_access(addr, sz_long)) {
 		dummy_put(addr, sz_long, l);
 	} else {
-		if ((addr & 0xffff) == 0x40) {
+		if (mbdmac_reg_address(addr) == 0x40) {
 			// long write to 0x40 = write byte to SASR
 			mbdmac_write_byte (wd_a3000, 0x41, l);
 		} else {
@@ -3885,7 +3895,7 @@ static void REGPARAM2 mbdmac_lput (uaecptr addr, uae_u32 l)
 }
 static void REGPARAM2 mbdmac_wput (uaecptr addr, uae_u32 w)
 {
-	if (addr & 0xc000) {
+	if (mbdmac_unmapped_access(addr, sz_word)) {
 		dummy_put(addr, sz_word, w);
 	} else {
 		mbdmac_write_word (wd_a3000, addr + 0, w);
@@ -3893,7 +3903,7 @@ static void REGPARAM2 mbdmac_wput (uaecptr addr, uae_u32 w)
 }
 static void REGPARAM2 mbdmac_bput (uaecptr addr, uae_u32 b)
 {
-	if (addr & 0xc000) {
+	if (mbdmac_unmapped_access(addr, sz_byte)) {
 		dummy_put(addr, sz_byte, b);
 	} else {
 		mbdmac_write_byte (wd_a3000, addr, b);


### PR DESCRIPTION
## Summary

- Apply the SDMAC `$7f`/`$ff` address normalization before detecting special SASR long writes.
- Route byte, word, and long accesses that cross the `$DD4000` decode boundary through the existing dummy memory handlers.

## Root cause

The SDMAC address-space fix in `8b874c33dec0d7b90a9116453d52dde0e2bf239d` correctly introduced `$80` register mirroring without DSP, `$100` mirroring with DSP, and Gary bus-timeout handling at `$DD4000` and above.

Two edge cases remained:

- The special low-byte-only SASR long-write path compared the unnormalized address, so mirrored accesses such as `$DD00C0` without DSP or `$DD0140` with DSP fell through to generic word writes.
- The timeout check only considered the starting address, so an access beginning below `$DD4000` and ending at or above it could still expose a mirrored SDMAC register.

## Impact

Mirrored SASR long writes now retain their required semantics, and accesses crossing the end of the decoded SDMAC range consistently use Gary timeout handling.

These cases were found while reviewing the corresponding Amiberry change: https://github.com/BlitterStudio/amiberry/pull/2185

## Validation

- Amiberry full macOS debug build: `cmake --build cmake-build-debug -j8`
- WinUAE Unix build with AppleClang 21:
  - `cmake -S . -B /private/tmp/winuae-sdmac-build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWINUAE_UNIX_WITH_CHD=OFF`
  - `cmake --build /private/tmp/winuae-sdmac-build --target winuae_unix -j8`
- `git diff --check origin/master...HEAD`
