### PR TITLE
68030 MMU MMU030_REG_FIXUP possible fix when bus error handler except…

### DIFF
--- a/cpummu30.cpp
+++ b/cpummu30.cpp
@@ -3428,6 +3428,7 @@ void m68k_do_rte_mmu030c (uaecptr a7)
 
 		regs.wb2_status = v >> 8;
 		regs.wb3_status = mmu030_state_2 >> 8;
+		mmu030_state_2 &= 0x00ff;
 		mmu030fixupmod(regs.wb2_status, 1, -1);
 		mmu030fixupmod(regs.wb3_status, 1, -1);
 


### PR DESCRIPTION
…ions are stacked for 030c path


the exact mirror of 765aa244 for 030c path