### PR TITLE
Optimize delayed custom write handling

### DIFF
--- a/custom.cpp
+++ b/custom.cpp
@@ -112,6 +112,7 @@ static int draw_line_next_line, draw_line_wclks;
 static uae_u32 rga_denise_cycle_line = 1;
 static struct pipeline_reg preg;
 static struct pipeline_func pfunc[MAX_PIPELINE_REG];
+static int pfunc_active_count;
 static uae_u16 prev_strobe;
 static bool vb_fast;
 static uae_u32 custom_state_flags;
@@ -155,6 +156,7 @@ static void pipelined_custom_write(evfunc2 func, uae_u16 v, uae_u16 cck)
 			p->func = func;
 			p->v = v;
 			p->cck = cck;
+			pfunc_active_count++;
 			return;
 		}
 	}
@@ -162,6 +164,9 @@ static void pipelined_custom_write(evfunc2 func, uae_u16 v, uae_u16 cck)
 }
 static void handle_pipelined_custom_write(bool now)
 {
+	if (!pfunc_active_count) {
+		return;
+	}
 	for (int i = 0 ; i < MAX_PIPELINE_REG; i++) {
 		struct pipeline_func *p = &pfunc[i];
 		if (p->func) {
@@ -169,6 +174,7 @@ static void handle_pipelined_custom_write(bool now)
 			if (!p->cck || now) {
 				auto f = p->func;
 				p->func = NULL;
+				pfunc_active_count--;
 				f(p->v);
 			}
 		}
@@ -6640,6 +6646,7 @@ void custom_reset(bool hardreset, bool keyboardreset)
 		struct pipeline_func *p = &pfunc[i];
 		memset(p, 0, sizeof(struct pipeline_func));
 	}
+	pfunc_active_count = 0;
 	rga_denise_cycle = 0;
 	rga_denise_cycle_start = 0;
 	rga_denise_cycle_count_end = 0;


### PR DESCRIPTION
## Summary

Delayed custom writes no longer make every idle CCK scan all three callback slots. Tracking whether any callbacks are pending lets the common idle path return immediately while preserving callback timing and re-entrant scheduling.

On a Raspberry Pi 4 running the demanding Jim Power title sequence in an A1200 Amiberry configuration, paired native builds measured:

| Metric | Baseline | Optimized | Change |
|---|---:|---:|---:|
| Frame rate | 35.175 FPS | 36.5125 FPS | +3.80% |
| Emulation time per frame | 27.54125 ms | 26.49875 ms | -3.79% |

Related: https://github.com/BlitterStudio/amiberry/pull/2234

## Validation

- MSVC x64 Release compilation of `custom.cpp`: 0 warnings, 0 errors
- `git diff --check`
- Amiberry multi-platform CI passed with the same core change

