### PR TITLE
RIPPLE - Add bank select logic + flash

### DIFF
--- a/flashrom.cpp
+++ b/flashrom.cpp
@@ -757,6 +757,8 @@ bool flash_write(void *fdv, uaecptr addr, uae_u8 v)
 	if (addr * other_byte_mult >= fd->allocsize) {
 		return false;
 	}
+	
+	int addr_masked = (addr & 0x7fff);
 
 	int oldstate = fd->state;
 	bool det = false;
@@ -779,29 +781,29 @@ bool flash_write(void *fdv, uaecptr addr, uae_u8 v)
 	}
 
 	// unlock
-	if ((addr & 0x7FFF) == 0x5555 && fd->state <= 2 && v == 0xaa) {
+	if (addr_masked == 0x5555 && fd->state <= 2 && v == 0xaa) {
 		fd->state = 1;
 		det = true;
 	}
-	if ((addr & 0x7FFF) == 0x2aaa && fd->state == 1 && v == 0x55) {
+	if (addr_masked == 0x2aaa && fd->state == 1 && v == 0x55) {
 		fd->state = 2;
 		det = true;
 	}
 
 	// software id exit and reset first byte
-	if ((addr & 0x7FFF) == 0x5555 && fd->state == 3 && v == 0xaa) {
+	if (addr_masked == 0x5555 && fd->state == 3 && v == 0xaa) {
 		fd->state = 1;
 		det = true;
 	}
 
 	// autoselect
-	if ((addr & 0x7FFF) == 0x5555 && fd->state == 2 && v == 0x90) {
+	if (addr_masked == 0x5555 && fd->state == 2 && v == 0x90) {
 		fd->state = 3;
 		det = true;
 	}
 
 	// data protect enable
-	if ((addr & 0x7FFF) == 0x5555 && fd->state == 2 && v == 0xa0) {
+	if (addr_masked == 0x5555 && fd->state == 2 && v == 0xa0) {
 		fd->state = 7;
 		det = true;
 		fd->writeprot = -1;
@@ -809,26 +811,26 @@ bool flash_write(void *fdv, uaecptr addr, uae_u8 v)
 	}
 
 	// data protect disable
-	if ((addr & 0x7FFF) == 0x5555 && fd->state == 6 && v == 0x20) {
+	if (addr_masked == 0x5555 && fd->state == 6 && v == 0x20) {
 		fd->state = 0;
 		fd->writeprot = 0;
 		return false;
 	}
 
 	// chip/sector erase/protect disable
-	if ((addr & 0x7FFF) == 0x5555 && fd->state == 2 && v == 0x80) {
+	if (addr_masked == 0x5555 && fd->state == 2 && v == 0x80) {
 		fd->state = 4;
 		det = true;
 	}
-	if ((addr & 0x7FFF) == 0x5555 && fd->state == 4 && v == 0xaa) {
+	if (addr_masked == 0x5555 && fd->state == 4 && v == 0xaa) {
 		fd->state = 5;
 		det = true;
 	}
-	if ((addr & 0x7FFF) == 0x2aaa && fd->state == 5 && v == 0x55) {
+	if (addr_masked == 0x2aaa && fd->state == 5 && v == 0x55) {
 		fd->state = 6;
 		det = true;
 	}
-	if ((addr & 0x7FFF) == 0x5555 && fd->state == 6 && v == 0x10) {
+	if (addr_masked == 0x5555 && fd->state == 6 && v == 0x10) {
 		for (int i = 0; i < fd->allocsize; i++)  {
 			int a = i * other_byte_mult;
 			if (fd->rom[a] != 0xff) {

--- a/flashrom.cpp
+++ b/flashrom.cpp
@@ -779,29 +779,29 @@ bool flash_write(void *fdv, uaecptr addr, uae_u8 v)
 	}
 
 	// unlock
-	if (addr == 0x5555 && fd->state <= 2 && v == 0xaa) {
+	if ((addr & 0x7FFF) == 0x5555 && fd->state <= 2 && v == 0xaa) {
 		fd->state = 1;
 		det = true;
 	}
-	if (addr == 0x2aaa && fd->state == 1 && v == 0x55) {
+	if ((addr & 0x7FFF) == 0x2aaa && fd->state == 1 && v == 0x55) {
 		fd->state = 2;
 		det = true;
 	}
 
 	// software id exit and reset first byte
-	if (addr == 0x5555 && fd->state == 3 && v == 0xaa) {
+	if ((addr & 0x7FFF) == 0x5555 && fd->state == 3 && v == 0xaa) {
 		fd->state = 1;
 		det = true;
 	}
 
 	// autoselect
-	if (addr == 0x5555 && fd->state == 2 && v == 0x90) {
+	if ((addr & 0x7FFF) == 0x5555 && fd->state == 2 && v == 0x90) {
 		fd->state = 3;
 		det = true;
 	}
 
 	// data protect enable
-	if (addr == 0x5555 && fd->state == 2 && v == 0xa0) {
+	if ((addr & 0x7FFF) == 0x5555 && fd->state == 2 && v == 0xa0) {
 		fd->state = 7;
 		det = true;
 		fd->writeprot = -1;
@@ -809,26 +809,26 @@ bool flash_write(void *fdv, uaecptr addr, uae_u8 v)
 	}
 
 	// data protect disable
-	if (addr == 0x5555 && fd->state == 6 && v == 0x20) {
+	if ((addr & 0x7FFF) == 0x5555 && fd->state == 6 && v == 0x20) {
 		fd->state = 0;
 		fd->writeprot = 0;
 		return false;
 	}
 
 	// chip/sector erase/protect disable
-	if (addr == 0x5555 && fd->state == 2 && v == 0x80) {
+	if ((addr & 0x7FFF) == 0x5555 && fd->state == 2 && v == 0x80) {
 		fd->state = 4;
 		det = true;
 	}
-	if (addr == 0x5555 && fd->state == 4 && v == 0xaa) {
+	if ((addr & 0x7FFF) == 0x5555 && fd->state == 4 && v == 0xaa) {
 		fd->state = 5;
 		det = true;
 	}
-	if (addr == 0x2aaa && fd->state == 5 && v == 0x55) {
+	if ((addr & 0x7FFF) == 0x2aaa && fd->state == 5 && v == 0x55) {
 		fd->state = 6;
 		det = true;
 	}
-	if (addr == 0x5555 && fd->state == 6 && v == 0x10) {
+	if ((addr & 0x7FFF) == 0x5555 && fd->state == 6 && v == 0x10) {
 		for (int i = 0; i < fd->allocsize; i++)  {
 			int a = i * other_byte_mult;
 			if (fd->rom[a] != 0xff) {

--- a/idecontrollers.cpp
+++ b/idecontrollers.cpp
@@ -671,10 +671,12 @@ static int get_ripple_reg(uaecptr addr, struct ide_board *board, int *portnum, i
 	int reg = -1;
 	int bankOffset = (board->userdata & 0x03) << 16;
 
-	if ((board->userdata & 0x100) == 0) {
-		*romoffset = (addr & board->mask);
-	} else if (addr & 0x10000) {
-		*romoffset = (addr & 0xFFFF) | bankOffset;
+	if (!(addr & 1)) {
+		if ((board->userdata & 0x100) == 0) {
+			*romoffset = ((addr & board->mask) >> 1);
+		} else if (addr & 0x10000) {
+			*romoffset = (((addr & 0xFFFF) | bankOffset) >> 1);
+		}
 	}
 
 	*portnum = (addr & 0x2000) ? 1 : 0;
@@ -1155,7 +1157,7 @@ static uae_u32 ide_read_byte2(struct ide_board *board, uaecptr addr)
 			int romoffset = -1;
 			int regnum = get_ripple_reg(addr,board,&portnum,&romoffset);
 			if (board->rom && romoffset >= 0) {
-				v = board->rom[romoffset];
+				v = flash_read(board->flashrom,romoffset);
 			} else if (!ide_isdrive(board->ide[portnum]) && !ide_isdrive(board->ide[portnum]->pair)) {
 				v = 0xff;
 			} else if (regnum >= 0 && board->ide[portnum]) {
@@ -1511,10 +1513,10 @@ static uae_u32 ide_read_word(struct ide_board *board, uaecptr addr)
 			int portnum = 0;
 			int romoffset = -1;
 			int regnum = get_ripple_reg(addr,board,&portnum,&romoffset);
-			if (romoffset >= 0) {
-				v = board->rom[romoffset];
+			if (board->rom && romoffset >= 0) {
+				v = flash_read(board->flashrom,romoffset);
 				v <<= 8;
-				v |= board->rom[romoffset + 1];
+				v |= 0xff;
 			} else if (regnum == IDE_DATA && board->ide[portnum]) {
 				v = get_ide_reg_multi(board, regnum, portnum, 1);
 			}
@@ -1961,6 +1963,8 @@ static void ide_write_byte(struct ide_board *board, uaecptr addr, uae_u8 v)
 			int reg = get_ripple_reg(addr,board,&portnum,&romoffset);
 			if ((addr & board->mask) == 0x8000) {
 				board->userdata = 0x100 | (v >> 6);
+			} else if (board->rom && romoffset >= 0) {
+				flash_write(board->flashrom,romoffset,v);
 			} else if (board->ide[portnum] && reg >= 0) {
 				put_ide_reg_multi(board,reg,v,portnum,1);
 			}
@@ -2200,6 +2204,8 @@ static void ide_write_word(struct ide_board *board, uaecptr addr, uae_u16 v)
 			int reg = get_ripple_reg(addr,board,&portnum,&romoffset);
 			if ((addr & board->mask) == 0x8000) {
 				board->userdata = 0x100 | (v >> 14);
+			} else if (board->rom && romoffset >= 0) {
+				flash_write(board->flashrom,romoffset,v >> 8);
 			} else if (reg >= 0 && board->ide[portnum]) {
 				put_ide_reg_multi(board,reg,v,portnum,1);
 			}
@@ -3444,7 +3450,7 @@ bool ripple_init(struct autoconfig_info *aci)
 	ide->configured     = 0;
 	ide->bank           = &ide_bank_generic;
 	ide->type           = RIPPLE_IDE;
-	ide->rom_size       = 262144;
+	ide->rom_size       = 131072;
 	ide->userdata       = 0;
 	ide->intena         = false;
 	ide->mask           = 131072 - 1;
@@ -3464,7 +3470,8 @@ bool ripple_init(struct autoconfig_info *aci)
 		ew(ide, i * 4, b);
 	}
 
-	load_rom_rc(aci->rc, ROMTYPE_RIPPLE, 131072, 0, ide->rom, 262144, LOADROM_EVENONLY_ODDONE);
+	ide->romfile = load_rom_rc_zfile(aci->rc, ROMTYPE_RIPPLE, 131072, 0, ide->rom, 131072, LOADROM_ONEFILL);
+	ide->flashrom = flash_new(ide->rom, ide->rom_size, ide->rom_size, 0x01, 0x20, ide->romfile, FLASHROM_PARALLEL_EEPROM | FLASHROM_DATA_PROTECT);
 
 	aci->addrbank = ide->bank;
 	return true;

--- a/idecontrollers.cpp
+++ b/idecontrollers.cpp
@@ -666,9 +666,17 @@ static int get_dev_hd_reg(uaecptr addr, struct ide_board* board)
 	return reg;
 }
 
-static int get_ripple_reg(uaecptr addr, struct ide_board *board, int *portnum)
+static int get_ripple_reg(uaecptr addr, struct ide_board *board, int *portnum, int *romoffset)
 {
 	int reg = -1;
+	int bankOffset = (board->userdata & 0x03) << 16;
+
+	if ((board->userdata & 0x100) == 0) {
+		*romoffset = (addr & board->mask);
+	} else if (addr & 0x10000) {
+		*romoffset = (addr & 0xFFFF) | bankOffset;
+	}
+
 	*portnum = (addr & 0x2000) ? 1 : 0;
 
 	if (addr & 0x3000) {
@@ -1143,17 +1151,14 @@ static uae_u32 ide_read_byte2(struct ide_board *board, uaecptr addr)
 
 		}
 	} else if (board->type == RIPPLE_IDE) {
-			if (board->rom && board->userdata == 0) {
-				v = board->rom[(addr & board->rom_mask)];
-				return v;
-			}
 			int portnum = 0;
-			int regnum = get_ripple_reg(addr,board,&portnum);
-			if (!ide_isdrive(board->ide[portnum]) && !ide_isdrive(board->ide[portnum]->pair)) {
+			int romoffset = -1;
+			int regnum = get_ripple_reg(addr,board,&portnum,&romoffset);
+			if (board->rom && romoffset >= 0) {
+				v = board->rom[romoffset];
+			} else if (!ide_isdrive(board->ide[portnum]) && !ide_isdrive(board->ide[portnum]->pair)) {
 				v = 0xff;
-				return v;
-			}
-			if (regnum >= 0 && board->ide[portnum]) {
+			} else if (regnum >= 0 && board->ide[portnum]) {
 				v = get_ide_reg_multi(board,regnum,portnum,1);
 			}
 
@@ -1503,15 +1508,14 @@ static uae_u32 ide_read_word(struct ide_board *board, uaecptr addr)
 			}
 
 		} else if (board->type == RIPPLE_IDE) {
-			if (board->rom && board->userdata == 0) {
-				v = board->rom[addr & board->rom_mask];
-				v <<= 8;
-				v |= board->rom[(addr + 1) & board->rom_mask];
-				return v;
-			}
 			int portnum = 0;
-			int regnum = get_ripple_reg(addr,board,&portnum);
-			if (regnum == IDE_DATA && board->ide[portnum]) {
+			int romoffset = -1;
+			int regnum = get_ripple_reg(addr,board,&portnum,&romoffset);
+			if (romoffset >= 0) {
+				v = board->rom[romoffset];
+				v <<= 8;
+				v |= board->rom[romoffset + 1];
+			} else if (regnum == IDE_DATA && board->ide[portnum]) {
 				v = get_ide_reg_multi(board, regnum, portnum, 1);
 			}
 
@@ -1951,10 +1955,13 @@ static void ide_write_byte(struct ide_board *board, uaecptr addr, uae_u8 v)
 			}
 
 		} else if (board->type == RIPPLE_IDE) {
-			if ((addr & 0x3000) && board->userdata == 0) board->userdata = 1;
+			if (addr & 0x3000) board->userdata |= 0x100;
 			int portnum = 0;
-			int reg = get_ripple_reg(addr,board,&portnum);
-			if (board->ide[portnum] && reg >= 0) {
+			int romoffset = -1;
+			int reg = get_ripple_reg(addr,board,&portnum,&romoffset);
+			if ((addr & board->mask) == 0x8000) {
+				board->userdata = 0x100 | (v >> 6);
+			} else if (board->ide[portnum] && reg >= 0) {
 				put_ide_reg_multi(board,reg,v,portnum,1);
 			}
 
@@ -2187,13 +2194,14 @@ static void ide_write_word(struct ide_board *board, uaecptr addr, uae_u16 v)
 			}
 
 		} else if (board->type == RIPPLE_IDE) {
-			if ((addr & 0x3000) && board->userdata == 0)
-				board->userdata = 1;
-			if (board->configured) {
-				int portnum = 0;
-				int reg = get_ripple_reg(addr, board, &portnum);
-				if (reg >= 0 && board->ide[portnum])
-					put_ide_reg_multi(board,reg,v,portnum,1);
+			if (addr & 0x3000) board->userdata |= 0x100;
+			int portnum = 0;
+			int romoffset = -1;
+			int reg = get_ripple_reg(addr,board,&portnum,&romoffset);
+			if ((addr & board->mask) == 0x8000) {
+				board->userdata = 0x100 | (v >> 14);
+			} else if (reg >= 0 && board->ide[portnum]) {
+				put_ide_reg_multi(board,reg,v,portnum,1);
 			}
 
 		} else if (board->type == AIDE_IDE) {
@@ -3436,7 +3444,7 @@ bool ripple_init(struct autoconfig_info *aci)
 	ide->configured     = 0;
 	ide->bank           = &ide_bank_generic;
 	ide->type           = RIPPLE_IDE;
-	ide->rom_size       = 131072;
+	ide->rom_size       = 262144;
 	ide->userdata       = 0;
 	ide->intena         = false;
 	ide->mask           = 131072 - 1;
@@ -3456,7 +3464,7 @@ bool ripple_init(struct autoconfig_info *aci)
 		ew(ide, i * 4, b);
 	}
 
-	load_rom_rc(aci->rc, ROMTYPE_RIPPLE, 65536, 0, ide->rom, 131072, LOADROM_EVENONLY_ODDONE);
+	load_rom_rc(aci->rc, ROMTYPE_RIPPLE, 131072, 0, ide->rom, 262144, LOADROM_EVENONLY_ODDONE);
 
 	aci->addrbank = ide->bank;
 	return true;


### PR DESCRIPTION
* Adds flash + bank select to more closely match the real hardware
* flashrom: mask command address bits (otherwise banked flash won't work) - on real AM29F010, SST39SF010 etc A15 and up are ignored